### PR TITLE
Use Rogue Variables to Represent Column Board Loading

### DIFF
--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -16,85 +16,165 @@ DEFAULT_LOADING = {
     'SA_AMP_GAIN_3':1.5,
     'SA_FB_FSADJ_R':2.0e3,
     'SA_FB_DAC_LOAD_R':25.0,
-    'SA_FB_AMP_GAIN_R':-4.7,
+    'SA_FB_AMP_GAIN':-4.7,
     'SA_FB_SHUNT_R':7.15e3,
-    'SQ1_FB_FSADJ_R':2.0e3,                     
+    'SQ1_FB_FSADJ_R':2.0e3,
     'SQ1_FB_DAC_LOAD_R':25.0,
-    'SQ1_FB_AMP_GAIN_R':-4.7,
+    'SQ1_FB_AMP_GAIN':-4.7,
     'SQ1_FB_SHUNT_R':11.3e3,
-    'SQ1_BIAS_FSADJ_R':2.0e3,                     
+    'SQ1_BIAS_FSADJ_R':2.0e3,
     'SQ1_BIAS_DAC_LOAD_R':25.0,
-    'SQ1_BIAS_AMP_GAIN_R':-4.7,
+    'SQ1_BIAS_AMP_GAIN':-4.7,
     'SQ1_BIAS_SHUNT_R':10.0e3}
 
 
 class ColumnLoading(pr.Device):
 
-    def __init__(self, column, overrides, **kwargs):
+    def __init__(self, column, **kwargs):
         super().__init__(**kwargs)
 
-        # Override defaults
-        self._dict = DEFAULT_LOADING.copy()
-        for k, v in self._dict.items():
-            print(f'{column=}, {k=}, {v=}')
-            self._dict[k] = v
+        self.column = column
 
-        # Create Rogue Variables from loading list
-        for k, v in self._dict.items():
-            self.add(pr.LocalVariable(
-                name = k,
-                value = v))
+        self.add(pr.LocalVariable(
+            name = 'SA_BIAS_SHUNT_R',
+            value = 15.0e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_OFFSET_R',
+            value = 4.02e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_FB_R',
+            value = 1.1e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_GAIN_R',
+            value = 100,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_GAIN_2',
+            value = 11,))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_GAIN_3',
+            value = 1.5,))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_FB_FSADJ_R',
+            value = 2.0e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_FB_DAC_LOAD_R',
+            value = 25.0,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_FB_AMP_GAIN',
+            value = -4.7,))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_FB_SHUNT_R',
+            value = 7.15e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_FB_FSADJ_R',
+            value = 2.0e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_FB_DAC_LOAD_R',
+            value = 25.0,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_FB_AMP_GAIN',
+            value = -4.7,))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_FB_SHUNT_R',
+            value = 11.3e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_BIAS_FSADJ_R',
+            value = 2.0e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_BIAS_DAC_LOAD_R',
+            value = 25.0,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_BIAS_AMP_GAIN',
+            value = -4.7,))
+        
+        self.add(pr.LocalVariable(
+            name = 'SQ1_BIAS_SHUNT_R',
+            value = 10.0e3,
+            units = u'\u03a9'))
+        
+        sa_vars = [
+            self.SA_OFFSET_R,
+            self.SA_AMP_FB_R,
+            self.SA_AMP_GAIN_R,
+            self.SA_AMP_GAIN_2,
+            self.SA_AMP_GAIN_3]
+
 
         self.add(pr.LinkVariable(
             name = 'AmpInConvFactor',
             units = u'\u03bcV/ADC',
             disp = '{:0.3f}',
             mode = 'RO',
-            dependencies = [
-                self.SA_OFFSET_R,
-                self.SA_AMP_FB_R,
-                self.SA_AMP_GAIN_R,
-                self.SA_AMP_GAIN_2,
-                self.SA_AMP_GAIN_3],
+            dependencies = sa_vars,
             linkedGet = lambda read: 1.0e6 * self.ampVin(1/2**13, 0.0)))
 
+        self.add(pr.LinkVariable(
+            name = 'AmpSaGain',
+            disp = '{:0.3f}',
+            mode = 'RO',
+            dependencies = sa_vars,
+            linkedGet = lambda read: 1 / self.ampVin(1.0, 0.0)))
 
+        
     def ampVin(self, vout, voffset):
         """Calculate SA_OUT an amplifier input given amp output and voffset"""
-        
-        G_OFF = 1.0/self.SA_OFFSET_R.get()
-        G_FB = 1.0/self.SA_AMP_FB_R.get()
-        G_GAIN = 1.0/self.SA_AMP_GAIN_R.get()
-        
-        V_OUT_1 = vout/(self.SA_AMP_GAIN_2.get()*self.SA_AMP_GAIN_3.get())
-            
+
+        G_OFF = 1.0/self.SA_OFFSET_R.value()
+        G_FB = 1.0/self.SA_AMP_FB_R.value()
+        G_GAIN = 1.0/self.SA_AMP_GAIN_R.value()
+
+        V_OUT_1 = vout/(self.SA_AMP_GAIN_2.value()*self.SA_AMP_GAIN_3.value())
+
         SA_OUT = ((G_OFF * voffset) + (G_FB * V_OUT_1)) / (G_OFF + G_FB + G_GAIN)
+
         return SA_OUT
-            
+
 
 
 class ColumnBoardLoading(pr.Device):
-    
+
     def __init__(self, overrides={}, **kwargs):
         super().__init__(**kwargs)
 
         for i in range(8):
-            col_overrides = {}            
+            col_overrides = {}
             if i in overrides:
                 col_overrides = overrides[i]
 
             self.add(ColumnLoading(
                 name = f'Column[{i}]',
                 column = i,
-                overrides = col_overrides))
+                defaults = col_overrides))
 
         self.ampVinVec = np.vectorize(self.ampVin)
-
-#     def __getitem__(self, key):
-#         return self._dict[key]
-
-#     def items(self):
-#         return self._dict.items()
 
     def ampVin(self, vout, voffset, col):
         return self.Column[col].ampVin(vout, voffset)
@@ -103,20 +183,12 @@ class ColumnBoardLoading(pr.Device):
         return [v for col in range(8) for k,v in self.Column[col].variables.items() if k.startswith(typ) and k.endswith(val)]
 
 
+
 class ColumnModule(pr.Device):
     def __init__(self,
                  # Channels 0 and 1 have FB attached after first stage
                  waveform_stream,
                  loading={},
-#                  loading={
-#                      0: {
-#                          'SA_AMP_FB_R': 1.0,
-#                          'SA_OFFSET_R': 1.0e20,
-#                          'SA_AMP_GAIN_R': 1.0e20},
-#                      1: {
-#                          'SA_AMP_FB_R': 1.0,
-#                          'SA_OFFSET_R': 1.0e20,
-#                          'SA_AMP_GAIN_R': 1.0e20}},                     
                  rows=64,
                  **kwargs):
         super().__init__(**kwargs)
@@ -196,6 +268,7 @@ class ColumnModule(pr.Device):
         cols = list(range(8))
 
         def _saOutGet(*, read=True, index=-1, check=True):
+            #print(f'ColumnModule._saOutGet({read=}, {index=}, {check=})')
             with self.root.updateGroup():
                 adc = self.SaOutAdc.get(read=read, index=index, check=check)
                 offset = self.SaBiasOffset.OffsetVoltageArray.get(read=read, index=index, check=check)
@@ -207,6 +280,7 @@ class ColumnModule(pr.Device):
                     return ret
 
         def _saOutNormGet(*, read=True, index=-1, check=True):
+            #print(f'ColumnModule._saOutNormGet({read=}, {index=}, {check=})')
             with self.root.updateGroup():
                 adc = self.SaOutAdc.get(read=read, index=index, check=check)
                 offset = 0.0
@@ -216,23 +290,23 @@ class ColumnModule(pr.Device):
                 else:
                     ret = self.Loading.ampVin(adc, offset, index) * 1e3
                     return ret
-                    
-        
+
+
         self.add(pr.LinkVariable(
             name = 'SaOut',
             dependencies = [self.SaOutAdc, *[x for x in self.SaBiasOffset.OffsetVoltage.values()]],
             units = 'mV',
-            disp = '{:0.03f}',            
+            disp = '{:0.03f}',
             linkedGet = _saOutGet))
 
         self.add(pr.LinkVariable(
             name = 'SaOutNorm',
             dependencies = [self.SaOutAdc],
             units = 'mV',
-            disp = '{:0.03f}',            
+            disp = '{:0.03f}',
             linkedGet = _saOutNormGet))
-            
-        
+
+
 
 #         self.add(pr.RemoteVariable(
 #             name = f'TestRam',
@@ -249,7 +323,7 @@ class ColumnModule(pr.Device):
 #             print(arg)
 #             offset, size = arg
 # #            ram = np.linspace(0, 2**32-1, 2**13-25, endpoint=False, dtype=np.uint32)
-#             ram = np.linspace(0, 2**32-1, size, endpoint=False, dtype=np.uint32)            
+#             ram = np.linspace(0, 2**32-1, size, endpoint=False, dtype=np.uint32)
 #             self.TestRam.set(value=ram, index=offset, write=True)
 
 
@@ -263,7 +337,7 @@ class ColumnModule(pr.Device):
 
             for v in self.SQ1Bias.Override.values():
                 v.set(value=arg, write=True)
-                
+
 
         @self.command()
         def InitDacAdc():
@@ -275,11 +349,10 @@ class ColumnModule(pr.Device):
             self.Ad9681Config.InternalPdwnMode.setDisp('Chip Run')
 
             self.DataPath.Ad9681Readout.Relock()
-            self.DataPath.Ad9681Readout.LostLockCountReset()            
+            self.DataPath.Ad9681Readout.LostLockCountReset()
 
             self.SaBiasDac.ZeroVoltages()
             self.TesBiasDac.ZeroVoltages()
 
     def initialize(self):
         self.InitDacAdc()
-            

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -166,7 +166,7 @@ class FastDacDriver(pr.Device):
 
 
     def _squidVoltageToDac(self, voltage, column):
-        dacCurrent = voltage / (self.dacLoad_deps[column].value() * self.ampGain[column].value())
+        dacCurrent = voltage / (self.dacLoad_deps[column].value() * self.ampGain_deps[column].value())
 #        print(f'dacCurrent = {dacCurrent}')
 
         dac = int(((dacCurrent/self.IOutFs[column].value())*8192)+8191)

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -10,10 +10,6 @@ class FastDacDriver(pr.Device):
                  typ,
                  loading,                 
                  rows=64,
-#                  rfsadj=[2.0E3]*8,
-#                  dacLoad=[25.0]*8,
-#                  ampGain=[-4.7]*8,
-#                  outResistance=[4.0e3]*8,
                  waveformTrigger=None,
                  **kwargs):
         super().__init__(**kwargs)
@@ -21,23 +17,12 @@ class FastDacDriver(pr.Device):
         if rows == 0:
             rows = 64
 
-#         print(rfsadj)
-#         self.iOutFs = [1.2 / r * 32 for r in rfsadj.values()]
-#         self.dacLoad = dacLoad
-#         self.ampGain = ampGain
-#         self.outResistance = outResistance
         self._waveformTrigger = waveformTrigger
 
         self.rfsadj_deps = loading.deps(typ, 'FSADJ_R')
         self.dacLoad_deps = loading.deps(typ, 'DAC_LOAD_R')
-        self.ampGain_deps = loading.deps(typ, 'AMP_GAIN_R')
+        self.ampGain_deps = loading.deps(typ, 'AMP_GAIN')
         self.outResistance_deps = loading.deps(typ, 'SHUNT_R')
-
-        print('FastDacDriver.__init__()')
-        print(self.rfsadj_deps)
-        print(self.dacLoad_deps)
-        print(self.ampGain_deps)
-        print(self.outResistance_deps)
 
         for col in range(8):
             self.add(pr.LinkVariable(

--- a/firmware/python/warm_tdm/_HardwareGroup.py
+++ b/firmware/python/warm_tdm/_HardwareGroup.py
@@ -65,7 +65,7 @@ class HardwareGroup(pyrogue.Device):
 
             # Instantiate the board Device tree and link it to the SRP
             self.add(warm_tdm.ColumnModule(name=f'ColumnBoard[{index}]', memBase=srp, expand=True, rows=rows, waveform_stream=dataStream))
-            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, loading=self.ColumnBoard[index].loading)
+            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, loading=self.ColumnBoard[index].Loading)
 
             # Link the data stream to the DataWriter
             if emulate is False:

--- a/firmware/python/warm_tdm/_SaBiasOffset.py
+++ b/firmware/python/warm_tdm/_SaBiasOffset.py
@@ -18,7 +18,7 @@ class SaBiasOffset(pr.Device):
                 if self.TriggerWaveform.get():
                     self._waveformTrigger()
                 self._dac.DacVoltage[ch].set(value, write=write)
-            
+
             self.add(pr.LinkVariable(
                 name = f'BiasVoltage[{i}]',
                 dependencies = [self._dac.DacVoltage[i]],
@@ -29,7 +29,7 @@ class SaBiasOffset(pr.Device):
                 units = 'V'))
 
 
-        for i in range(8):            
+        for i in range(8):
             self.add(pr.LinkVariable(
                 name = f'OffsetVoltage[{i}]',
                 variable = self._dac.DacVoltage[i+8],
@@ -39,8 +39,8 @@ class SaBiasOffset(pr.Device):
             self.add(pr.LinkVariable(
                 name = f'BiasCurrent[{i}]',
                 dependencies = [self.BiasVoltage[i]],
-                linkedGet = lambda read, ch=i: self.BiasVoltage[ch].get(read=read) * 1e6 / loading[ch]['SA_BIAS_SHUNT_R'],
-                linkedSet = lambda value, write, ch=i: self.BiasVoltage[ch].set( (value/1e6) * loading[ch]['SA_BIAS_SHUNT_R'] , write=write),
+                linkedGet = lambda read, ch=i: self.BiasVoltage[ch].get(read=read) * 1e6 / loading.Column[ch].SA_BIAS_SHUNT_R.get(read=read),
+                linkedSet = lambda value, write, ch=i: self.BiasVoltage[ch].set((value/1e6) * loading.Column[ch].SA_BIAS_SHUNT_R.value(), write=write),
                 disp = '{:0.01f}',
                 units = u'\u03bcA'))
 
@@ -74,4 +74,3 @@ class SaBiasOffset(pr.Device):
 #             dacValue = dacChannel.get(read=read)
 #             return dacValue / 15e3
 #         return _getChannel
-    

--- a/firmware/python/warm_tdm/_WaveformCapture.py
+++ b/firmware/python/warm_tdm/_WaveformCapture.py
@@ -194,7 +194,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
 
         for ch in range(len(tmpAmpVin)):
             for sample in range(len(tmpAmpVin[0])):
-                tmpAmpVin[ch][sample] = self.loading.ampVin(tmpVoltage[ch][sample], 0.0, ch)
+                tmpAmpVin[ch][sample] = tmpVoltage[ch][sample] / 200.0
 
         self.add(pr.LocalVariable(
             name = 'RawData',
@@ -320,13 +320,13 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
                 dependencies = [self.RawData],
                 linkedGet = _getAvg))
 
-            self.add(pr.LocalVariable(
+            self.add(pr.LinkVariable(
                 name = f'AmpInConvFactor[{i}]',
-                units = u'\u03bcV/ADC',
-                disp = '{:0.3f}',
+#                units = u'\u03bcV/ADC',
+ #               disp = '{:0.3f}',
                 guiGroup = 'AmpInConvFactor',
-                value = 1.0e6*self.loading.ampVin(1/2**13, 0.0, i)))
-
+                variable = self.loading.Column[i].AmpInConvFactor))
+  
 
         self.add(MultiPlot(
             name='MultiPlot',

--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -459,17 +459,17 @@ class Group(pr.Device):
         # Column board acces variables
         #####################################
 
-        self.add(pr.LocalVariable(
-            name = 'SA_FB_SHUNT_R',
-            hidden = True,
-            mode = 'RO',
-            value = {k:v['SA_FB_SHUNT_R'] for k,v in self.HardwareGroup.ColumnBoard[0].loading.items()}))
+#         self.add(pr.LocalVariable(
+#             name = 'SA_FB_SHUNT_R',
+#             hidden = True,
+#             mode = 'RO',
+#             value = {k:v['SA_FB_SHUNT_R'] for k,v in self.HardwareGroup.ColumnBoard[0].loading.Column[items()}))
 
-        self.add(pr.LocalVariable(
-            name = 'SQ1_FB_SHUNT_R',
-            hidden = True,
-            mode = 'RO',
-            value = {k:v['SQ1_FB_SHUNT_R'] for k,v in self.HardwareGroup.ColumnBoard[0].loading.items()}))
+#         self.add(pr.LocalVariable(
+#             name = 'SQ1_FB_SHUNT_R',
+#             hidden = True,
+#             mode = 'RO',
+#             value = {k:v['SQ1_FB_SHUNT_R'] for k,v in self.HardwareGroup.ColumnBoard[0].loading.items()}))
         
 
         self.add(GroupLinkVariable(

--- a/software/python/warm_tdm_api/_SaTune.py
+++ b/software/python/warm_tdm_api/_SaTune.py
@@ -15,7 +15,7 @@ class SinglePlot(pr.LinkVariable):
         self._ax = self._fig.add_subplot()
         self._fig.suptitle(u'SA OUT (mV) vs. SA FB (\u03bcA)')
 
-    def _plot_ax(self, ax, col, curves, shunt):
+    def _plot_ax(self, ax, col, curves):
         warm_tdm_api.plotCurveDataDict(
             ax=ax,
             curveDataDict=curves,

--- a/software/python/warm_tdm_api/_SaTune.py
+++ b/software/python/warm_tdm_api/_SaTune.py
@@ -19,7 +19,7 @@ class SinglePlot(pr.LinkVariable):
         warm_tdm_api.plotCurveDataDict(
             ax=ax,
             curveDataDict=curves,
-            ax_title=f'Channel {col} - FB Shunt = {shunt/1000} kOhms',
+            ax_title=f'Channel {col}', ## - FB Shunt = {shunt/1000} kOhms',
             xlabel=u'SA FB (\u03bcA)',
             ylabel='SA Out (mV)',
             legend_title='SA Bias Curves')
@@ -34,9 +34,9 @@ class SinglePlot(pr.LinkVariable):
         if col == -1:
             col = self.parent.PlotColumn.value()
 
-        shunt = self.parent.parent.SA_FB_SHUNT_R.value()            
+#        shunts = [self.parent.loading.Column[x].SA_FB_SHUNT_R.value() for x in range(8)]
 
-        self._plot_ax(self._ax, col, tune[col], shunt[col])
+        self._plot_ax(self._ax, col, tune[col]) ##, shunts[col])
 
         return self._fig
 
@@ -54,14 +54,14 @@ class MultiPlot(SinglePlot):
 
     def linkedGet(self):
         tune = self.parent.SaTuneOutput.value()
-        shunt = self.parent.parent.SA_FB_SHUNT_R.value()        
+ #       shunts = [self.parent.loading.Column[x].SA_FB_SHUNT_R.value() for x in range(8)]
 
         if tune == {}:
             return self._fig
 
         axes = self._ax.reshape(8)
         for col, ax in enumerate(axes):
-            self._plot_ax(ax, col, tune[col], shunt[col])
+            self._plot_ax(ax, col, tune[col]) ##, shunts[col])
 
         return self._fig
 

--- a/software/python/warm_tdm_api/_Sq1Tune.py
+++ b/software/python/warm_tdm_api/_Sq1Tune.py
@@ -39,7 +39,7 @@ class SinglePlot(pr.LinkVariable):
         else:
             col, row = index
 
-        shunt = self.parent.parent.SQ1_FB_SHUNT_R.value()            
+ #       shunts = [self.parent.Loading.Column[x].SQ1_FB_SHUNT_R.value() for x in range(8)]            
 
         self._plot_ax(self._ax, col, row, tune[row][col])
 
@@ -59,7 +59,7 @@ class MultiPlot(SinglePlot):
 
     def linkedGet(self, index=-1):
         tune = self.parent.Sq1TuneOutput.value()
-        shunt = self.parent.parent.SQ1_FB_SHUNT_R.value()        
+#        shunt = self.parent.parent.SQ1_FB_SHUNT_R.value()        
 
         if tune == {}:
             return self._fig

--- a/software/scripts/warmTdmGui.py
+++ b/software/scripts/warmTdmGui.py
@@ -20,8 +20,8 @@ from warm_tdm_api import PhysicalMap as pm
 #rogue.Logging.setFilter('pyrogue.memory.Master', rogue.Logging.Debug)
 #rogue.Logging.setFilter('pyrogue.memory.Hub', rogue.Logging.Debug)
 #rogue.Logging.setFilter('pyrogue.memory.Transaction', rogue.Logging.Debug)
+#logging.getLogger('pyrogue.Variable.RemoteVariable.GroupRoot.Group.HardwareGroup.RowBoard[0]').setLevel(logging.DEBUG)
 #logging.getLogger('pyrogue.Device').setLevel(logging.DEBUG)
-#logging.getLogger('pyrogue.Variable').setLevel(logging.DEBUG)
 
 parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
Provides rogue variables for many column board resistors that determine amplifier gains and output currents.
These are then used to convert DAC and ADC values to physical units.