### PR TITLE
Update submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "firmware/submodules/surf"]
 	path = firmware/submodules/surf
-	url = git@github.com:slaclab/surf
+	url = https://github.com/slaclab/surf
 [submodule "firmware/submodules/ruckus"]
 	path = firmware/submodules/ruckus
-	url = git@github.com:slaclab/ruckus
+	url = https://github.com/slaclab/ruckus


### PR DESCRIPTION
Change back to the https:// format for submodules. Seems to work better with all versions of git.