### PR TITLE
Add modular amplifier models for calculating DAC/ADC to Voltage/Current conversions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 # Exclude data files
 *.npy
 *.dat
-
+*.*~

--- a/firmware/python/warm_tdm/_Amplifiers.py
+++ b/firmware/python/warm_tdm/_Amplifiers.py
@@ -1,0 +1,256 @@
+import pyrogue as pr
+
+class SaAmplifier(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def addGainVars(self, sa_vars):
+        
+        self.add(pr.LinkVariable(
+            name = 'AmpInConvFactor',
+            units = u'\u03bcV/ADC',
+            disp = '{:0.3f}',
+            mode = 'RO',
+            dependencies = sa_vars,
+            linkedGet = lambda read: 1.0e6 * self.ampVin(1/2**13, 0.0)))
+
+        self.add(pr.LinkVariable(
+            name = 'AmpSaGain',
+            disp = '{:0.3f}',
+            mode = 'RO',
+            dependencies = sa_vars,
+            linkedGet = lambda read: 1 / self.ampVin(1.0, 0.0)))
+
+
+class ColumnBoardC00SaAmp(SaAmplifier):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(pr.LocalVariable(
+            name = 'SA_OFFSET_R',
+            value = 4.02e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_FB_R',
+            value = 1.1e3,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_GAIN_R',
+            value = 100,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_GAIN_2',
+            value = 11,))
+        
+        self.add(pr.LocalVariable(
+            name = 'SA_AMP_GAIN_3',
+            value = 1.5,))
+        
+        sa_vars = [
+            self.SA_OFFSET_R,
+            self.SA_AMP_FB_R,
+            self.SA_AMP_GAIN_R,
+            self.SA_AMP_GAIN_2,
+            self.SA_AMP_GAIN_3]
+
+        self.addGainVars(sa_vars)
+
+
+        
+    def ampVin(self, vout, voffset):
+        """Calculate SA_OUT an amplifier input given amp output and voffset"""
+
+        G_OFF = 1.0/self.SA_OFFSET_R.value()
+        G_FB = 1.0/self.SA_AMP_FB_R.value()
+        G_GAIN = 1.0/self.SA_AMP_GAIN_R.value()
+
+        V_OUT_1 = vout/(self.SA_AMP_GAIN_2.value()*self.SA_AMP_GAIN_3.value())
+
+        SA_OUT = ((G_OFF * voffset) + (G_FB * V_OUT_1)) / (G_OFF + G_FB + G_GAIN)
+
+        return SA_OUT
+
+
+class FEAmplifier3(SaAmplifier):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # Make these into variables
+
+        # Stage 1 Instrumentation Amplifier
+        # RF1 = R34/R33
+        # RG1 = R6
+        self.RF1 = 100.0
+        self.RG1 = 18.20
+
+
+        self.GAIN_1 = 1 + (( 2 * self.RF1) / self.RG1 )
+
+        # Stage 2 Summing Differential Input Amplifier
+        self.RF2 = 100.0
+        self.RG2 = 33.2
+        self.ROFF = 33.2 # Offset gain
+
+        self.GAIN_COLUMN = 3.67
+        
+
+    def ampVout(self, vin, voffset):
+        # Make it more readable
+        RF2 = self.RF2
+        RG2 = self.RG2
+        ROFF = self.ROFF
+        
+        # Gain of stage 1 Intrumentation Amplifier    
+        gain1 = self.GAIN_1
+
+        # Differential stage 1 voltage
+        v1p = (vin * gain1) / 2
+        v1n = -(vin * gain1) / 2
+
+        # Stage 2 positive amp terminal voltage
+        v2 = v1p * self.RF2 / (self.RG2 + self.RF2)
+
+        # Stage 2 output voltage
+        # Ugly equation from wolfram alpha
+        vout2 = (RF2 * ( RF2 * RG2 * (v1p - 2 * voffset) + 2 * RF2 * v1p * ROFF + 2 * RG2 * (v1p * ROFF - RG2 * voffset))) / (2 * RG2 * ROFF * (RF2 + RG2))
+        #vout2 = self.RF2 * ((self.GOFF * voffset) - (self.GOFF * v2) + (self.GF2 * v2) - (self.GG2 * v1n) + (self.GG2 * v2))
+
+        # Final output voltage after column board amplifiers
+        vout = vout2 * self.GAIN_COLUMN
+
+        return vout
+                           
+
+    def ampVin(self, vadc, voffset):
+
+        RF2 = self.RF2
+        RG2 = self.RG2
+        ROFF = self.ROFF
+
+        vout2 = vadc / self.GAIN_COLUMN
+        
+
+        # Ugly equation from wolfram alpha
+        v1p = (2 * RG2 * (RF2 + RG2) * (RF2 * voffset + vout2 * ROFF)) / (RF2 * (RF2 * (RG2 - (2 * ROFF)) - (2 * RG2 * ROFF)))
+        v1p = -1.0 * v1n
+
+        v1 = v1p - v1n
+
+        vin = v1 / self.GAIN_1
+
+        return vin
+        
+    
+class FastDacAmplifierSE(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(pr.LocalVariable(
+            name = 'FSADJ',
+            value = 2.0e3,
+            units = '\u03A9'))
+
+        self.add(pr.LinkVariable(
+            name = 'IOUTFS',
+            units = 'A',
+            linkedGet = lambda: 1.2 / self.FSADJ.value() * 32))
+
+        self.add(pr.LocalVariable(
+            name = 'LoadR',
+            value = 24.9,
+            units = '\u03A9'))
+
+        self.add(pr.LocalVariable(
+            name = 'InputR',
+            value = 1.0e3,
+            units = '\u03A9'))
+
+        self.add(pr.LocalVariable(
+            name = 'FbR',
+            value = 4.02e3,
+            units = '\u03A9'))
+
+        self.add(pr.LocalVariable(
+            name = 'FilterR',
+            value = 49.9 * 3,
+            units = '\u03A9'))
+
+        self.add(pr.LocalVariable(
+            name = 'ShuntR',
+            value = 1.0e3,
+            units = '\u03A9'))
+
+        self.add(pr.LocalVariable(
+            name = 'CableR',
+            value = 100.0,
+            units = '\u03A9'))
+
+        self.add(pr.LinkVariable(
+            name = 'Gain',
+            dependencies = [self.FbR, self.InputR],
+            linkedGet = self.gain))
+
+        self.add(pr.LinkVariable(
+            name = 'OutR',
+            dependencies = [self.FilterR, self.ShuntR, self.CableR],
+            units = '\u03A9',
+            linkedGet = self.rout))
+
+    def gain(self):
+        return self.FbR.value() / self.InputR.value()
+
+    def rout(self):
+        return self.FilterR.value() + self.ShuntR.value() + self.CableR.value()
+
+    def dacToOutVoltage(self, dac):
+        iOutFs = self.IOUTFS.value()
+        iOutA = (dac/16384) * iOutFs
+        iOutB = ((16383-dac)/16384) * iOutFs
+        dacCurrent = (iOutA, iOutB)
+
+        gain = self.gain()
+        load = self.LoadR.value()
+
+        vin = [iOutA * load, iOutB * load]
+
+        vout = (vin[0] - vin[1]) * gain
+        return vout
+
+    def dacToOutCurrent(self, dac):
+        """ Calculate output current in uA """
+        vout = self.dacToOutVoltage(dac)
+        iout = vout / self.rout()
+        return iout * 1e6
+
+    def outVoltageToDac(self, voltage):
+        print(f'outVoltageToDac({voltage=})')
+        gain = self.gain()
+        load = self.LoadR.value()
+        ioutfs = self.IOUTFS.value()
+        vin = voltage / gain
+        iin = vin / load
+        iina = (iin + ioutfs) / 2
+        dac =  int((iina / ioutfs) * 16384)
+        print(f'{gain=}, {load=}, {ioutfs=}, {vin=}, {iin=}, {iina=}, {dac=}')
+        return int(dac)
+
+    def outCurrentToDac(self, current):
+        vout = current * 1e-6 * self.rout()
+        return self.outVoltageToDac(vout)
+
+
+class FastDacAmplifierDiff(FastDacAmplifierSE):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def gain(self):
+        return 2 * self.FbR.value() / self.InputR.value()
+
+    def rout(self):
+        return (2 * self.FilterR.value()) + (2 * self.ShuntR.value()) + self.CableR.value()
+    

--- a/firmware/python/warm_tdm/_Amplifiers.py
+++ b/firmware/python/warm_tdm/_Amplifiers.py
@@ -206,7 +206,7 @@ class FastDacAmplifierSE(pr.Device):
             linkedGet = self.rout))
 
     def gain(self):
-        ret = self.FbR.value() / self.InputR.value()
+        ret = self.FbR.value() / (self.InputR.value())
         if self.Invert.value() is True:
             ret = ret * -1
         return ret

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -186,10 +186,9 @@ class ColumnBoardLoading(pr.Device):
 
 class ColumnModule(pr.Device):
     def __init__(self,
-                 waveform_stream,
-                 amplifierClass,
+                 amplifierClass=warm_tdm.ColumnBoardC00SaAmp,
 #                 loading={},
-#                 rows=64,
+                 rows=1,
                  **kwargs):
         super().__init__(**kwargs)
 
@@ -197,8 +196,8 @@ class ColumnModule(pr.Device):
         for i in range(8):
             self.add(amplifierClass(
                 name = f'Amp[{i}]'))
-                
-        
+
+        self.amplifiers = [self.Amp[i] for i in range(8)]
  
         self.add(warm_tdm.WarmTdmCore(
             offset = 0x00000000,
@@ -206,8 +205,7 @@ class ColumnModule(pr.Device):
 
         self.add(warm_tdm.DataPath(
             offset = 0xC0300000,
-            expand = True,
-            waveform_stream = waveform_stream))
+            expand = True,))
 
         self.add(warm_tdm.Ad5679R(
             name = 'SaBiasDac',
@@ -216,7 +214,7 @@ class ColumnModule(pr.Device):
 
         self.add(warm_tdm.SaBiasOffset(
             dac = self.SaBiasDac,
-            loading = self.Loading,
+#            loading = self.Loading,
             waveformTrigger = self.DataPath.WaveformCapture.WaveformTrigger))
 
         self.add(warm_tdm.Ad5679R(
@@ -236,13 +234,13 @@ class ColumnModule(pr.Device):
         self.add(warm_tdm.FastDacDriver(
             name = 'SQ1Bias',
             offset = 0xC0400000,
- #           rows = rows,
+            rows = rows,
         ))
 
         self.add(warm_tdm.FastDacDriver(
             name = 'SQ1Fb',
             offset =0xC0500000,
-  #          rows = rows,
+            rows = rows,
         ))
 
 
@@ -269,7 +267,7 @@ class ColumnModule(pr.Device):
                 adc = self.SaOutAdc.get(read=read, index=index, check=check)
                 offset = self.SaBiasOffset.OffsetVoltageArray.get(read=read, index=index, check=check)
                 if index == -1:
-                    ret = np.array([self.Amp[i].ampVin(adc, offset) * 1e3 for i in range(cols)])
+                    ret = np.array([self.Amp[i].ampVin(adc, offset) * 1e3 for i in range(8)])
                     return ret
                 else:
                     ret = self.Amp[index].ampVin(adc, offset) * 1e3
@@ -281,7 +279,7 @@ class ColumnModule(pr.Device):
                 adc = self.SaOutAdc.get(read=read, index=index, check=check)
                 offset = 0.0
                 if index == -1:
-                    ret = np.array([self.Amp.ampVin(adc, offset) * 1e3 for i in range(cols)])
+                    ret = np.array([self.Amp[i].ampVin(adc, offset) * 1e3 for i in range(8)])
                     return ret
                 else:
                     ret = self.Amp[index].ampVin(adc, offset) * 1e3

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -214,7 +214,6 @@ class ColumnModule(pr.Device):
 
         self.add(warm_tdm.SaBiasOffset(
             dac = self.SaBiasDac,
-#            loading = self.Loading,
             waveformTrigger = self.DataPath.WaveformCapture.WaveformTrigger))
 
         self.add(warm_tdm.Ad5679R(
@@ -249,7 +248,7 @@ class ColumnModule(pr.Device):
             offset = 0xC0200000))
 
         #########################################
-        # Compute SA Out based on loading options
+        # Compute SA Out based on amplifier config
         #########################################
         self.add(pr.LinkVariable(
             name = 'SaOutAdc',

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -264,25 +264,25 @@ class ColumnModule(pr.Device):
         def _saOutGet(*, read=True, index=-1, check=True):
             #print(f'ColumnModule._saOutGet({read=}, {index=}, {check=})')
             with self.root.updateGroup():
-                adc = self.SaOutAdc.get(read=read, index=index, check=check)
-                offset = self.SaBiasOffset.OffsetVoltageArray.get(read=read, index=index, check=check)
+                adcs = self.SaOutAdc.get(read=read, index=index, check=check)
+                offsets = self.SaBiasOffset.OffsetVoltageArray.get(read=read, index=index, check=check)
                 if index == -1:
-                    ret = np.array([self.Amp[i].ampVin(adc, offset) * 1e3 for i in range(8)])
+                    ret = np.array([self.Amp[i].ampVin(adcs[i], offsets[i]) * 1e3 for i in range(8)])
                     return ret
                 else:
-                    ret = self.Amp[index].ampVin(adc, offset) * 1e3
+                    ret = self.Amp[index].ampVin(adcs, offsets) * 1e3
                     return ret
 
         def _saOutNormGet(*, read=True, index=-1, check=True):
             #print(f'ColumnModule._saOutNormGet({read=}, {index=}, {check=})')
             with self.root.updateGroup():
-                adc = self.SaOutAdc.get(read=read, index=index, check=check)
+                adcs = self.SaOutAdc.get(read=read, index=index, check=check)
                 offset = 0.0
                 if index == -1:
-                    ret = np.array([self.Amp[i].ampVin(adc, offset) * 1e3 for i in range(8)])
+                    ret = np.array([self.Amp[i].ampVin(adcs[i], offset) * 1e3 for i in range(8)])
                     return ret
                 else:
-                    ret = self.Amp[index].ampVin(adc, offset) * 1e3
+                    ret = self.Amp[index].ampVin(adcs, offset) * 1e3
                     return ret
 
 

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -228,18 +228,21 @@ class ColumnModule(pr.Device):
         self.add(warm_tdm.FastDacDriver(
             name = 'SAFb',
             offset = 0xC0600000,
+            shunt = 7.15e3,
             rows = rows,            
         ))
 
         self.add(warm_tdm.FastDacDriver(
             name = 'SQ1Bias',
             offset = 0xC0400000,
+            shunt = 10.0e3,
             rows = rows,
         ))
 
         self.add(warm_tdm.FastDacDriver(
             name = 'SQ1Fb',
             offset =0xC0500000,
+            shunt = 11.3e3,
             rows = rows,
         ))
 

--- a/firmware/python/warm_tdm/_DataPath.py
+++ b/firmware/python/warm_tdm/_DataPath.py
@@ -9,7 +9,7 @@ import warm_tdm
 
 
 class DataPath(pr.Device):
-    def __init__(self, waveform_stream, **kwargs):
+    def __init__(self,  **kwargs):
         super().__init__(**kwargs)
 
         self.add(surf.devices.analog_devices.Ad9681Readout(
@@ -24,8 +24,7 @@ class DataPath(pr.Device):
 
         self.add(warm_tdm.WaveformCapture(
             offset = 9 << 16,
-            enabled = True,
-            stream = waveform_stream))
+            enabled = True,))
 
         self.add(AdcFilters(
             enabled = False,

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -4,36 +4,88 @@ import pyrogue as pr
 
 import warm_tdm
 
+class FastDacMem(pr.Device):
+    def __init__(self, size, amp, **kwargs):
+        super().__init__(**kwargs)
+
+        self.amp = amp
+
+        self.add(pr.RemoteVariable(
+            name = f'Raw',
+            offset = kwargs['offset'],
+            base = pr.UInt,
+            numValues = size,
+            valueBits = 14,
+            valueStride = 32))
+
+        self.add(pr.LinkVariable(
+            name = f'Current',
+            dependencies = [self.Raw],
+            disp = '{:0.3f}',
+            units = '\u03bcA',
+            linkedGet = self.getCurrent,
+            linkedSet = self.setCurrent))
+
+        self.add(pr.LinkVariable(
+            name = f'Voltage',
+            dependencies = [self.Raw],
+            disp = '{:0.3f}',
+            units = 'V',
+            linkedGet = self.getVoltage,
+            linkedSet = self.setVoltage))
+
+    def getCurrent(self, index, read):
+        dacs = self.Raw.get(read=read, index=index)
+        if index == -1:
+            currents = [self.amp.dacToOutCurrent(dac) for dac in dacs]
+            currents = np.array(currents, dtype=np.float64)
+        else:
+            currents = self.amp.outCurrentToDac(dac)
+
+        return currents
+
+    def setCurrent(self, value, index, write):
+        if index == -1:
+            dacs = [self.amp.outCurrentToDac(current) for current in value]
+        else:
+            dacs = self.amp.outCurrentToDac(value)
+
+        self.Raw.set(index=index, write=write, value=dacs)
+
+    def getVoltage(self, index, read):
+        dacs = self.Raw.get(read=read, index=index)
+        if index == -1:
+            voltages = [self.amp.dacToOutVoltage(dac) for dac in dacs]
+            voltages = np.array(voltages, dtype=np.float64)
+        else:
+            voltages = self.amp.outVoltageToDac(dacs)
+
+        return voltages
+
+    def setVoltage(self, value, index, write):
+        if index == -1:
+            dacs = [self.amp.outVoltageToDac(voltage) for voltage in value]
+        else:
+            dacs = self.amp.outVoltageToDac(value)
+
+        self.Raw.set(index=index, write=write, value=dacs)
+
+
+
 class FastDacDriver(pr.Device):
 
-    def __init__(self,
-                 typ,
-                 loading,                 
-                 waveformTrigger=None,
-                 **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         rows = 1
 
-        self._waveformTrigger = waveformTrigger
+        # Create devices that hold amplifier configuration
+        for i in range(8):
+            self.add(FastDacAmplifierSE(
+                name = f'Amp[{i}]',
+                hidden = True))
 
-        self.rfsadj_deps = loading.deps(typ, 'FSADJ_R')
-        self.dacLoad_deps = loading.deps(typ, 'DAC_LOAD_R')
-        self.ampGain_deps = loading.deps(typ, 'AMP_GAIN')
-        self.outResistance_deps = loading.deps(typ, 'SHUNT_R')
-
-        for col in range(8):
-            self.add(pr.LinkVariable(
-                name = f'IOutFs[{col}]',
-                mode = 'RO',
-                hidden = True,
-                dependencies = [self.rfsadj_deps[col]],
-                linkedGet = lambda read, i=col: 1.2 / self.rfsadj_deps[i].get(read=read) * 32))
-            
-
-        self.add(pr.LocalVariable(
-            name = 'TriggerWaveform',
-            value = False))
+        
 
         for col in range(8):
             self.add(pr.RemoteVariable(
@@ -51,7 +103,7 @@ class FastDacDriver(pr.Device):
                 units = u'\u03bcA',
                 disp = '{:0.03f}',
                 pollInterval = 1,
-                linkedGet = lambda x=col: self._dacToSquidCurrent(self.DacRawNow[x].value(), x)))
+                linkedGet = lambda x=col: self.Amp[x].dacToOutCurrent(self.DacRawNow[x].value())))
             
         
         for col in range(8):
@@ -67,11 +119,11 @@ class FastDacDriver(pr.Device):
             # Current Conversion
             ####################
             def _overCurrentGet(index, read, x=col):
-                ret = self._dacToSquidCurrent(self.OverrideRaw[x].value(), x) 
+                ret = self.Amp[x].dacToOutCurrent(self.OverrideRaw[x].value()) 
                 return ret
 
             def _overCurrentSet(value, index, write, x=col):
-                self.OverrideRaw[x].set(self._squidCurrentToDac(value, x), write=write)
+                self.OverrideRaw[x].set(self.Amp[x].outCurrentToDac(value), write=write)
 
             self.add(pr.LinkVariable(
                 name = f'OverrideCurrent[{col}]',
@@ -86,13 +138,13 @@ class FastDacDriver(pr.Device):
             # Voltage Conversion
             ####################
             def _overVoltageGet(index, read, x=col):
-                ret = self._dacToSquidVoltage(self.OverrideRaw[x].value(), x)
+                ret = self.Amp[x].dacToCurrent(self.OverrideRaw[x].value())
                 #print(f'_overGet - OverrideRaw[{x}].value() = {self.OverrideRaw[x].value()} - voltage = {voltage}')
                 return ret
 
             def _overVoltageSet(value, index, write, x=col):
                 #print(f'Override[{x}].set()')
-                self.OverrideRaw[x].set(self._squidVoltageToDac(value, x), write=write)
+                self.OverrideRaw[x].set(self.Amp[x].outVoltageToDac(value), write=write)
 
             self.add(pr.LinkVariable(
                 name = f'OverrideVoltage[{col}]',
@@ -106,78 +158,80 @@ class FastDacDriver(pr.Device):
 
         for col in range(8):
 
-            self.add(pr.RemoteVariable(
+            self.add(pr.FastDacMem(
                 name = f'ColumnRaw[{col}]',
                 offset = col << 12,
-                base = pr.UInt,
-                mode = 'RW',
-                bitSize = 32*rows,
-                numValues = rows,
-                valueBits = 14,
-                valueStride = 32))
+                amp = self.Amp[col],
+                size = rows))
+#                 base = pr.UInt,
+#                 mode = 'RW',
+#                 bitSize = 32*rows,
+#                 numValues = rows,
+#                 valueBits = 14,
+#                 valueStride = 32))
 
             
-        for col in range(8):
-            self.add(pr.LinkVariable(
-                name = f'ColumnVoltages[{col}]',
-                dependencies = [self.ColumnRaw[col]],
-                disp = '{:0.03f}',
-                units = 'V',
-                linkedGet = self._getVoltageFunc(col),
-                linkedSet = self._setVoltageFunc(col)))
+#         for col in range(8):
+#             self.add(pr.LinkVariable(
+#                 name = f'ColumnVoltages[{col}]',
+#                 dependencies = [self.ColumnRaw[col]],
+#                 disp = '{:0.03f}',
+#                 units = 'V',
+#                 linkedGet = self._getVoltageFunc(col),
+#                 linkedSet = self._setVoltageFunc(col)))
 
-        for col in range(8):
+#         for col in range(8):
 
-            self.add(pr.LinkVariable(
-                name = f'ColumnCurrents[{col}]',
-                dependencies = [self.ColumnVoltages[col]],
-                disp = '{:0.03f}',
-                units = u'\u03bcA',
-                linkedGet = self._getCurrentFunc(col),
-                linkedSet = self._setCurrentFunc(col)))
+#             self.add(pr.LinkVariable(
+#                 name = f'ColumnCurrents[{col}]',
+#                 dependencies = [self.ColumnVoltages[col]],
+#                 disp = '{:0.03f}',
+#                 units = u'\u03bcA',
+#                 linkedGet = self._getCurrentFunc(col),
+#                 linkedSet = self._setCurrentFunc(col)))
             
 
-        @self.command()
-        def RamTest():
-            for col in range(8):
-                self.Channel[col].set(0, [(col<<6)+j for j in range(64)], write=False)
-#                for j in range(64):
-#                    value = (i<<6)+j
-#                    print(f'Writing {value:x} to Ch {i} Row {j}')
-#                    self.Channel[i].Row[j].set(j, value, write=False)
-#                    self.Channel[i].set(j, [value], write=False)
+#         @self.command()
+#         def RamTest():
+#             for col in range(8):
+#                 self.Channel[col].set(0, [(col<<6)+j for j in range(64)], write=False)
+# #                for j in range(64):
+# #                    value = (i<<6)+j
+# #                    print(f'Writing {value:x} to Ch {i} Row {j}')
+# #                    self.Channel[i].Row[j].set(j, value, write=False)
+# #                    self.Channel[i].set(j, [value], write=False)
 
-            self.writeAndVerifyBlocks()
+#             self.writeAndVerifyBlocks()
 
-    def _dacToCurrent(self, dac, column):
-        iOutFs = self.IOutFs[column].value()
-        iOutA = (dac/16384) * iOutFs
-        iOutB = ((16383-dac)/16384) * iOutFs
-        current = (iOutA, iOutB)
-#        print(f'_dacToCurrent({dac}) = {current}')
-        return current
+#     def _dacToCurrent(self, dac, column):
+#         iOutFs = self.IOutFs[column].value()
+#         iOutA = (dac/16384) * iOutFs
+#         iOutB = ((16383-dac)/16384) * iOutFs
+#         current = (iOutA, iOutB)
+# #        print(f'_dacToCurrent({dac}) = {current}')
+#         return current
 
-    def _dacToSquidVoltage(self, dac, column):
-        current = self._dacToCurrent(dac, column)
-        voltage = (current[0]-current[1]) * self.dacLoad_deps[column].value() * self.ampGain_deps[column].value()
-#        print(f'_dacToSquidVoltage({dac}) = {voltage}')
-        return voltage
+#     def _dacToSquidVoltage(self, dac, column):
+#         current = self._dacToCurrent(dac, column)
+#         voltage = (current[0]-current[1]) * self.dacLoad_deps[column].value() * self.ampGain_deps[column].value()
+# #        print(f'_dacToSquidVoltage({dac}) = {voltage}')
+#         return voltage
 
-    def _dacToSquidCurrent(self, dac, column):
-        return self._dacToSquidVoltage(dac, column) / self.outResistance_deps[column].value() * 1e6
+#     def _dacToSquidCurrent(self, dac, column):
+#         return self._dacToSquidVoltage(dac, column) / self.outResistance_deps[column].value() * 1e6
 
 
-    def _squidVoltageToDac(self, voltage, column):
-        dacCurrent = voltage / (self.dacLoad_deps[column].value() * self.ampGain_deps[column].value())
-#        print(f'dacCurrent = {dacCurrent}')
+#     def _squidVoltageToDac(self, voltage, column):
+#         dacCurrent = voltage / (self.dacLoad_deps[column].value() * self.ampGain_deps[column].value())
+# #        print(f'dacCurrent = {dacCurrent}')
 
-        dac = int(((dacCurrent/self.IOutFs[column].value())*8192)+8191)
-        dac = max(min(2**14-1, dac), 0)
-#        print(f'_squidVoltageToDac({voltage}) = {dac}')
-        return dac
+#         dac = int(((dacCurrent/self.IOutFs[column].value())*8192)+8191)
+#         dac = max(min(2**14-1, dac), 0)
+# #        print(f'_squidVoltageToDac({voltage}) = {dac}')
+#         return dac
 
-    def _squidCurrentToDac(self, current, column):
-        return self._squidVoltageToDac(current * 1e-6 * self.outResistance_deps[column].value(), column)
+#     def _squidCurrentToDac(self, current, column):
+#         return self._squidVoltageToDac(current * 1e-6 * self.outResistance_deps[column].value(), column)
     
 
 
@@ -195,39 +249,39 @@ class FastDacDriver(pr.Device):
 #             self.Column[column].set(value=dacValue, index=row, write=write)
 #         return _setChannel
 
-    def _getVoltageFunc(self, column):
-        def _getVoltage(read, index):
-            ret = self.ColumnRaw[column].get(read=read, index=index)
-            if index == -1:
-                return np.vectorize(self._dacToSquidVoltage)(ret, column)
-            else:
-                return self._dacToSquidVoltage(ret, column)
-        return _getVoltage
+#     def _getVoltageFunc(self, column):
+#         def _getVoltage(read, index):
+#             ret = self.ColumnRaw[column].get(read=read, index=index)
+#             if index == -1:
+#                 return np.vectorize(self._dacToSquidVoltage)(ret, column)
+#             else:
+#                 return self._dacToSquidVoltage(ret, column)
+#         return _getVoltage
 
-    def _setVoltageFunc(self, column):
-        def _setVoltage(value, write, index):
-            if index == -1:
-                dacValue = np.array([self._squidVoltageToDac(v, column) for v in value], np.uint32)
-            else:
-                dacValue = self._squidVoltageToDac(value, column)
-            self.ColumnRaw[column].set(value=dacValue, index=index, write=write)
-        return _setVoltage
+#     def _setVoltageFunc(self, column):
+#         def _setVoltage(value, write, index):
+#             if index == -1:
+#                 dacValue = np.array([self._squidVoltageToDac(v, column) for v in value], np.uint32)
+#             else:
+#                 dacValue = self._squidVoltageToDac(value, column)
+#             self.ColumnRaw[column].set(value=dacValue, index=index, write=write)
+#         return _setVoltage
 
-    def _getCurrentFunc(self, column):
-        def _getCurrent(read, index):
-            ret = self.ColumnRaw[column].get(read=read, index=index)
-            if index == -1:
-                return np.vectorize(self._dacToSquidCurrent)(ret, column)
-            else:
-                return self._dacToSquidCurrent(ret, column)
-        return _getCurrent
+#     def _getCurrentFunc(self, column):
+#         def _getCurrent(read, index):
+#             ret = self.ColumnRaw[column].get(read=read, index=index)
+#             if index == -1:
+#                 return np.vectorize(self._dacToSquidCurrent)(ret, column)
+#             else:
+#                 return self._dacToSquidCurrent(ret, column)
+#         return _getCurrent
 
-    def _setCurrentFunc(self, column):
-        def _setCurrent(value, write, index):
-            if index == -1:
-                dacValue = np.array([self._squidCurrentToDac(v, column) for v in value], np.uint32)
-            else:
-                dacValue = self._squidCurrentToDac(value, column)
-            self.ColumnRaw[column].set(value=dacValue, index=index, write=write)
-        return _setCurrent
+#     def _setCurrentFunc(self, column):
+#         def _setCurrent(value, write, index):
+#             if index == -1:
+#                 dacValue = np.array([self._squidCurrentToDac(v, column) for v in value], np.uint32)
+#             else:
+#                 dacValue = self._squidCurrentToDac(value, column)
+#             self.ColumnRaw[column].set(value=dacValue, index=index, write=write)
+#         return _setCurrent
 

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -74,14 +74,14 @@ class FastDacMem(pr.Device):
 
 class FastDacDriver(pr.Device):
 
-    def __init__(self, **kwargs):
+    def __init__(self, rows, **kwargs):
         super().__init__(**kwargs)
 
-        rows = 1
-
+        self.rows = rows
+        
         # Create devices that hold amplifier configuration
         for i in range(8):
-            self.add(FastDacAmplifierSE(
+            self.add(warm_tdm.FastDacAmplifierSE(
                 name = f'Amp[{i}]',
                 hidden = True))
 
@@ -138,7 +138,7 @@ class FastDacDriver(pr.Device):
             # Voltage Conversion
             ####################
             def _overVoltageGet(index, read, x=col):
-                ret = self.Amp[x].dacToCurrent(self.OverrideRaw[x].value())
+                ret = self.Amp[x].dacToOutCurrent(self.OverrideRaw[x].value())
                 #print(f'_overGet - OverrideRaw[{x}].value() = {self.OverrideRaw[x].value()} - voltage = {voltage}')
                 return ret
 
@@ -158,7 +158,7 @@ class FastDacDriver(pr.Device):
 
         for col in range(8):
 
-            self.add(pr.FastDacMem(
+            self.add(FastDacMem(
                 name = f'ColumnRaw[{col}]',
                 offset = col << 12,
                 amp = self.Amp[col],

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -40,7 +40,7 @@ class FastDacMem(pr.Device):
             currents = [self.amp.dacToOutCurrent(dac) for dac in dacs]
             currents = np.array(currents, dtype=np.float64)
         else:
-            currents = self.amp.outCurrentToDac(dac)
+            currents = self.amp.outCurrentToDac(dacs)
 
         return currents
 
@@ -159,7 +159,7 @@ class FastDacDriver(pr.Device):
         for col in range(8):
 
             self.add(FastDacMem(
-                name = f'ColumnRaw[{col}]',
+                name = f'Column[{col}]',
                 offset = col << 12,
                 amp = self.Amp[col],
                 size = rows))

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -74,7 +74,7 @@ class FastDacMem(pr.Device):
 
 class FastDacDriver(pr.Device):
 
-    def __init__(self, rows, **kwargs):
+    def __init__(self, shunt, rows, **kwargs):
         super().__init__(**kwargs)
 
         self.rows = rows
@@ -83,8 +83,8 @@ class FastDacDriver(pr.Device):
         for i in range(8):
             self.add(warm_tdm.FastDacAmplifierSE(
                 name = f'Amp[{i}]',
-                defaults = {'Invert': True},
-                hidden = True))
+                defaults = {'Invert': True, 'ShuntR': shunt, 'FbR': 4.7e3},
+                hidden = False))
         
 
         for col in range(8):

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -83,8 +83,8 @@ class FastDacDriver(pr.Device):
         for i in range(8):
             self.add(warm_tdm.FastDacAmplifierSE(
                 name = f'Amp[{i}]',
+                defaults = {'Invert': True},
                 hidden = True))
-
         
 
         for col in range(8):

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -138,7 +138,7 @@ class FastDacDriver(pr.Device):
             # Voltage Conversion
             ####################
             def _overVoltageGet(index, read, x=col):
-                ret = self.Amp[x].dacToOutCurrent(self.OverrideRaw[x].value())
+                ret = self.Amp[x].dacToOutVoltage(self.OverrideRaw[x].value())
                 #print(f'_overGet - OverrideRaw[{x}].value() = {self.OverrideRaw[x].value()} - voltage = {voltage}')
                 return ret
 

--- a/firmware/python/warm_tdm/_HardwareGroup.py
+++ b/firmware/python/warm_tdm/_HardwareGroup.py
@@ -81,7 +81,7 @@ class HardwareGroup(pyrogue.Device):
                 ))
             
             pidDebug = [warm_tdm.PidDebugger(name=f'PidDebug[{i}]', hidden=False, col=i, fastDacDriver=self.ColumnBoard[index].SQ1Fb) for i in range(8)]
-            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, loading=self.ColumnBoard[index].Loading)
+            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, amplifier=self.ColumnBoard[index].amplifiers)
 
             # Link the data stream to the DataWriter
             if emulate is False:

--- a/firmware/python/warm_tdm/_HardwareGroup.py
+++ b/firmware/python/warm_tdm/_HardwareGroup.py
@@ -80,7 +80,7 @@ class HardwareGroup(pyrogue.Device):
                 rows=rows))
             
             pidDebug = [warm_tdm.PidDebugger(name=f'PidDebug[{i}]', hidden=False, col=i, fastDacDriver=self.ColumnBoard[index].SQ1Fb) for i in range(8)]
-            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, amplifier=self.ColumnBoard[index].amplifiers)
+            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, amplifiers=self.ColumnBoard[index].amplifiers)
 
             # Link the data stream to the DataWriter
             if emulate is False:

--- a/firmware/python/warm_tdm/_HardwareGroup.py
+++ b/firmware/python/warm_tdm/_HardwareGroup.py
@@ -75,9 +75,10 @@ class HardwareGroup(pyrogue.Device):
             # Instantiate the board Device tree and link it to the SRP
             self.add(warm_tdm.ColumnModule(
                 name=f'ColumnBoard[{index}]',
-                memBase=srp, expand=True,
+                memBase=srp,
+                expand=True,
 #                rows=rows,
-                waveform_stream=None))
+                ))
             
             pidDebug = [warm_tdm.PidDebugger(name=f'PidDebug[{i}]', hidden=False, col=i, fastDacDriver=self.ColumnBoard[index].SQ1Fb) for i in range(8)]
             waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, loading=self.ColumnBoard[index].Loading)
@@ -130,7 +131,11 @@ class HardwareGroup(pyrogue.Device):
                 srp == srpStream
 
             # Instantiate the board Device tree and link it to the SRP
-            self.add(warm_tdm.RowModule(name=f'RowBoard[{rowIndex}]', memBase=srp, expand=True, enabled=True))
+            self.add(warm_tdm.RowModule(
+                name=f'RowBoard[{rowIndex}]',
+                memBase=srp,
+                expand=True,
+                enabled=True))
 
         self.add(pyrogue.LocalVariable(
             name = 'ReadoutList',

--- a/firmware/python/warm_tdm/_PidDebugger.py
+++ b/firmware/python/warm_tdm/_PidDebugger.py
@@ -59,7 +59,7 @@ class PidDebugger(pr.DataReceiver):
             disp = '{:0.03f}',
             units = u'\u03bcA',
             dependencies = [self.Sq1FbPreRaw, self.Column],
-            linkedGet = lambda: fastDacDriver._dacToSquidCurrent(self.Sq1FbPreRaw.value(), col)))
+            linkedGet = lambda: fastDacDriver.Amp[self.Column.value()].dacToOutCurrent(self.Sq1FbPreRaw.value())))
 
         self.add(pr.RemoteVariable(
             name = 'Sq1FbPostRaw',
@@ -74,7 +74,7 @@ class PidDebugger(pr.DataReceiver):
             disp = '{:0.03f}',
             units = u'\u03bcA',
             dependencies = [self.Sq1FbPostRaw, self.Column],
-            linkedGet = lambda: fastDacDriver._dacToSquidCurrent(self.Sq1FbPostRaw.value(), col)))
+            linkedGet = lambda: fastDacDriver.Amp[self.Column.value()].dacToOutCurrent(self.Sq1FbPostRaw.value())))
         
 
     def process(self, frame):

--- a/firmware/python/warm_tdm/_SaBiasOffset.py
+++ b/firmware/python/warm_tdm/_SaBiasOffset.py
@@ -2,8 +2,10 @@ import pyrogue as pr
 import numpy as np
 
 class SaBiasOffset(pr.Device):
-    def __init__(self, dac, loading, waveformTrigger, **kwargs):
+    def __init__(self, dac, waveformTrigger, **kwargs):
         super().__init__(**kwargs)
+
+        self.shunt = 15.0e3
 
         self._dac = dac
         self._waveformTrigger = waveformTrigger
@@ -39,8 +41,8 @@ class SaBiasOffset(pr.Device):
             self.add(pr.LinkVariable(
                 name = f'BiasCurrent[{i}]',
                 dependencies = [self.BiasVoltage[i]],
-                linkedGet = lambda read, ch=i: self.BiasVoltage[ch].get(read=read) * 1e6 / loading.Column[ch].SA_BIAS_SHUNT_R.get(read=read),
-                linkedSet = lambda value, write, ch=i: self.BiasVoltage[ch].set((value/1e6) * loading.Column[ch].SA_BIAS_SHUNT_R.value(), write=write),
+                linkedGet = lambda read, ch=i: self.BiasVoltage[ch].get(read=read) * 1e6 / self.shunt,
+                linkedSet = lambda value, write, ch=i: self.BiasVoltage[ch].set((value/1e6) * self.shunt, write=write),
                 disp = '{:0.01f}',
                 units = u'\u03bcA'))
 

--- a/firmware/python/warm_tdm/_WaveformCapture.py
+++ b/firmware/python/warm_tdm/_WaveformCapture.py
@@ -31,7 +31,7 @@ def array_iter(channel, array):
             yield (i, array[:,i])
 
 class WaveformCapture(pr.Device):
-    def __init__(self, stream, **kwargs):
+    def __init__(self, stream=None, **kwargs):
 #        rogue.interfaces.stream.Slave.__init__(self)
         pr.Device.__init__(self, **kwargs)
 

--- a/firmware/python/warm_tdm/_WaveformCapture.py
+++ b/firmware/python/warm_tdm/_WaveformCapture.py
@@ -175,11 +175,11 @@ class WaveformCapture(pr.Device):
 
 class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
 
-    def __init__(self, amplifier, **kwargs):
+    def __init__(self, amplifiers, **kwargs):
         rogue.interfaces.stream.Slave.__init__(self)
         pr.Device.__init__(self, **kwargs)
 
-        self.amplifier = amplifier
+        self.amplifiers = amplifiers
 
         def _conv(adc):
             return adc/2**13
@@ -285,7 +285,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
                 disp = '{:0.3f}',
                 guiGroup = 'RmsNoiseAmpInX',
                 dependencies = [self.RmsNoiseVADC[i]],
-                linkedGet = lambda read, ch=i: self.amplifier[ch].ampVin(self.RmsNoiseVADC[ch].get(read=read), 0.0)))
+                linkedGet = lambda read, ch=i: self.amplifiers[ch].ampVin(self.RmsNoiseVADC[ch].get(read=read), 0.0)))
 
         for i in range(8):
             def _getPkPk(read, x=i):
@@ -325,7 +325,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
  #               disp = '{:0.3f}',
                 mode = 'RO',
                 guiGroup = 'AmpInConvFactor',
-                variable = self.amplifier[i].AmpInConvFactor))
+                variable = self.amplifiers[i].AmpInConvFactor))
 
 
         self.add(MultiPlot(
@@ -373,7 +373,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
             if channel >= 8:
                 for sample in range(len(voltages)):
                     for ch in range(len(voltages[0])):
-                        ampVin[sample, ch] = self.loading.ampVin(voltages[sample, ch], 0.0, ch)
+                        ampVin[sample, ch] = self.amplifiers[ch].ampVin(voltages[sample, ch], 0.0)
 
                 d = {ch: {
                     'ADC Counts': adcs[:,ch],
@@ -384,7 +384,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
             else:
                 print(f'Setting data for channel {channel}')
                 for sample in range(len(voltages)):
-                    ampVin[sample, channel] = self.loading.ampVin(voltages[sample, channel], 0.0, channel)
+                    ampVin[sample] = self.amplifiers[channel].ampVin(voltages[sample], 0.0)
 
                 d[channel]['ADC Counts'] = adcs
                 d[channel]['V@ADC'] = voltages

--- a/firmware/python/warm_tdm/_WaveformCapture.py
+++ b/firmware/python/warm_tdm/_WaveformCapture.py
@@ -31,7 +31,7 @@ def array_iter(channel, array):
             yield (i, array[:,i])
 
 class WaveformCapture(pr.Device):
-    def __init__(self, stream=None, **kwargs):
+    def __init__(self, **kwargs):
 #        rogue.interfaces.stream.Slave.__init__(self)
         pr.Device.__init__(self, **kwargs)
 
@@ -175,11 +175,11 @@ class WaveformCapture(pr.Device):
 
 class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
 
-    def __init__(self, loading, **kwargs):
+    def __init__(self, amplifier, **kwargs):
         rogue.interfaces.stream.Slave.__init__(self)
         pr.Device.__init__(self, **kwargs)
 
-        self.loading = loading
+        self.amplifier = amplifier
 
         def _conv(adc):
             return adc/2**13
@@ -285,7 +285,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
                 disp = '{:0.3f}',
                 guiGroup = 'RmsNoiseAmpInX',
                 dependencies = [self.RmsNoiseVADC[i]],
-                linkedGet = lambda read, ch=i: self.loading.ampVin(self.RmsNoiseVADC[ch].get(read=read), 0.0, ch)))
+                linkedGet = lambda read, ch=i: self.amplifier[ch].ampVin(self.RmsNoiseVADC[ch].get(read=read), 0.0)))
 
         for i in range(8):
             def _getPkPk(read, x=i):
@@ -325,7 +325,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
  #               disp = '{:0.3f}',
                 mode = 'RO',
                 guiGroup = 'AmpInConvFactor',
-                variable = self.loading.Column[i].AmpInConvFactor))
+                variable = self.amplifier[i].AmpInConvFactor))
 
 
         self.add(MultiPlot(

--- a/firmware/python/warm_tdm/__init__.py
+++ b/firmware/python/warm_tdm/__init__.py
@@ -8,6 +8,7 @@ from warm_tdm._Ad9106 import *
 ## may be copied, modified, propagated, or distributed except according to 
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
+from warm_tdm._Amplifiers import *
 from warm_tdm._TimingRx import *
 from warm_tdm._TimingTx import *
 from warm_tdm._Timing import *

--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -254,7 +254,7 @@ class Group(pr.Device):
             host=groupConfig.host,
             colBoards=groupConfig.columnBoards,
             rowBoards=groupConfig.rowBoards,
-#            rows=len(groupConfig.rowMap),
+            rows=1,
             plots=plots,
             groups=['Hardware'],
             expand=True))
@@ -519,7 +519,7 @@ class Group(pr.Device):
             config = self.config,
             hidden = True,
 #            units = 'mA',
-            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.ColumnCurrents[m.channel]
+            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.Column[m.channel].Current
                             for m in self.config.columnMap]))
 
         self.add(GroupLinkVariable(
@@ -541,7 +541,7 @@ class Group(pr.Device):
             config = self.config,
             hidden = True,
 #            units = 'V',
-            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.ColumnVoltages[m.channel]
+            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.Column[m.channel].Voltage
                             for m in self.config.columnMap]))
 
         self.add(GroupLinkVariable(
@@ -562,7 +562,7 @@ class Group(pr.Device):
                          'Values can be accessed as a full 2D array or pass a (col, row) tuple for the index key to access each value.',
             config = self.config,
             hidden = True,
-            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Bias.ColumnCurrents[m.channel]
+            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Bias.Column[m.channel].Current
                             for m in self.config.columnMap]))
 
         self.add(GroupLinkVariable(
@@ -582,7 +582,7 @@ class Group(pr.Device):
                          'Values can be accessed as a full 2D array or pass a (col, row) tuple for the index key to access each value.',
             config = self.config,
             hidden = True,
-            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Bias.ColumnVoltages[m.channel]
+            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Bias.Column[m.channel].Voltage
                             for m in self.config.columnMap]))
 
 
@@ -604,7 +604,7 @@ class Group(pr.Device):
                          'Values can be accessed as a full 2D array or pass a (col, row) tuple for the index key to access each value.',
             config = self.config,
             hidden = True,
-            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Fb.ColumnCurrents[m.channel]
+            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Fb.Column[m.channel].Current
                             for m in self.config.columnMap]))
 
         self.add(GroupLinkVariable(
@@ -624,7 +624,7 @@ class Group(pr.Device):
                          'Values can be accessed as a full 2D array or pass a (col, row) tuple for the index key to access each value.',
             config = self.config,
             hidden = True,
-            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Fb.ColumnVoltages[m.channel]
+            dependencies = [self.HardwareGroup.ColumnBoard[m.board].SQ1Fb.Column[m.channel].Voltage
                             for m in self.config.columnMap]))
 
 

--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -126,34 +126,6 @@ class RowTuneIndexVariable(GroupLinkVariable):
         with self.parent.root.updateGroup():
             return self._value
 
-class Amplifier(object):
-    def __init__(self):
-
-        self.Rbias = 15e3
-        self.Roff = 4.22e3
-        self.Rgain = 100
-        self.Rfb = 1.1e3
-        self.Rcable = 200
-
-        self.Gbias = 1.0/self.Rbias
-        self.Goff = 1.0/self.Roff
-        self.Ggain = 1.0/self.Rgain
-        self.Gfb = 1.0/self.Rfb
-        self.Gcable = 1.0/self.Rcable
-
-        self.G2 = 11
-        self.G3 = 1.5
-
-    def Vout(self, Vin, Voff):
-        return self.Rfb * (Vin*(self.Ggain + self.Goff + self.Gfb) - Voff*self.Goff) * self.G2 *self.G3
-
-    def Vin(self, Vout, Voffset):
-        return ((Vout/(self.G2*self.G3)) * self.Gfb + Voffset * self.Goff) / (self.Ggain + self.Goff + self.Gfb)
-
-    def SaOut(self, Vout, Vbias, Voffset):
-        return self.Vin(Vout, Voffset)
-    #return (self.Vin(Vout, Voffset) * (self.Gbias + self.Gcable) - Vbias * self.Gbias) / self.Gcable
-
 
 class SaOutVariable(GroupLinkVariable):
     def __init__(self, config, disp='{:0.04f}', **kwargs):

--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -276,7 +276,7 @@ class Group(pr.Device):
         self.add(pr.LocalVariable(
             name='NumRows',
             description='Total number of rows in the Group. NumRowBoards * 32.',
-            value=len(self.config.rowMap),
+            value=self.config.numRows,
             mode='RO',
             groups='TopApi'))
 

--- a/software/python/warm_tdm_api/_Mapping.py
+++ b/software/python/warm_tdm_api/_Mapping.py
@@ -46,6 +46,8 @@ class GroupConfig(object):
 
         self.numColumns = len(self.columnMap)
         self.numRows = len(self.rowMap)
+        if self.numRows == 0:
+            self.numRows = 1
 
         self.rowOrder = rowOrder
         if self.rowOrder is None:

--- a/software/python/warm_tdm_api/_Sq1Tune.py
+++ b/software/python/warm_tdm_api/_Sq1Tune.py
@@ -29,7 +29,7 @@ class SinglePlot(pr.LinkVariable):
     def linkedGet(self, index=-1, read=False):
         tune = self.parent.Sq1TuneOutput.value()
         
-        if tune == {}:
+        if tune == {} or tune == []:
             return self._fig
 
 
@@ -39,8 +39,10 @@ class SinglePlot(pr.LinkVariable):
         else:
             col, row = index
 
- #       shunts = [self.parent.Loading.Column[x].SQ1_FB_SHUNT_R.value() for x in range(8)]            
+        print(f'Sq1TunePlot - {row=}, {col=}')
 
+ #       shunts = [self.parent.Loading.Column[x].SQ1_FB_SHUNT_R.value() for x in range(8)]            
+ 
         self._plot_ax(self._ax, col, row, tune[row][col])
 
         return self._fig
@@ -61,7 +63,7 @@ class MultiPlot(SinglePlot):
         tune = self.parent.Sq1TuneOutput.value()
 #        shunt = self.parent.parent.SQ1_FB_SHUNT_R.value()        
 
-        if tune == {}:
+        if tune == {} or tune == []:
             return self._fig
 
         if index == -1:
@@ -258,6 +260,8 @@ class Sq1TuneProcess(pr.Process):
         with self.root.updateGroup(0.25):
             ret = warm_tdm_api.sq1Tune(group=self.parent, process=self)
         self.Sq1TuneOutput.set(value = [[col.asDict() for col in row] for row in ret])
+        print('SQ1Tune Output')
+        print(self.Sq1TuneOutput.value())
 
     def _saveData(self,arg):
         print(f"Sq1Tune - Save data called with {arg=}")

--- a/software/python/warm_tdm_api/_Tuning.py
+++ b/software/python/warm_tdm_api/_Tuning.py
@@ -373,7 +373,7 @@ def sq1FbSweep(*, group, bias, fbRange, row, process):
     Iterates through Sq1Fb values determined by lowoffset,
     highoffset,step. Generates curve points with saOffset()
     """
-
+    print(f'sq1FbSweep({bias=}, {fbRange=}, {row=})')
     colCount = len(group.ColumnMap.get())
     curves = [warm_tdm_api.Curve(bias[i]) for i in range(colCount)]
     numSteps = len(fbRange[0])
@@ -414,6 +414,8 @@ def sq1BiasSweep(group, row, process):
 
     # Extract iteration steps from Rogue variables
     # Create CurveData obects for storing output data
+    print(f'saBiasSweep({row=})')
+    
     colCount = len(group.ColumnMap.get())
     numBiasSteps = process.Sq1BiasNumSteps.get()
     numFbSteps = process.Sq1FbNumSteps.get()

--- a/software/python/warm_tdm_api/_Tuning.py
+++ b/software/python/warm_tdm_api/_Tuning.py
@@ -208,7 +208,7 @@ def saTune(*, group, process=None, doSet=True):
     """
 #    group.Init()
 
-    group.RowTuneIndex.set(0)
+    #group.RowTuneIndex.set(0)
     #group.RowTuneMode.set(True)
     saBiasResults = saBiasSweep(group=group,process=process)
 

--- a/software/scripts/warmTdmClientCmd.py
+++ b/software/scripts/warmTdmClientCmd.py
@@ -38,7 +38,7 @@ args = parser.parse_known_args()[0]
 
 
 client = pyrogue.interfaces.VirtualClient(args.host, args.port)
-group = client.root.Group
+#group = client.root.Group
 
 
 def setSaFb(channel, value):

--- a/software/scripts/warmTdmGui.py
+++ b/software/scripts/warmTdmGui.py
@@ -22,9 +22,9 @@ from warm_tdm_api import PhysicalMap as pm
 #rogue.Logging.setFilter('pyrogue.memory.Transaction', rogue.Logging.Debug)
 #logging.getLogger('pyrogue.Variable.RemoteVariable.GroupRoot.Group.HardwareGroup.RowBoard[0]').setLevel(logging.DEBUG)
 #logging.getLogger('pyrogue.Device').setLevel(logging.DEBUG)
-#rogue.Logging.setFilter('pyrogue.protocols.packetizer.Core', rogue.Logging.Debug)
-#rogue.Logging.setFilter('pyrogue.protocols.packetizer.Controller', rogue.Logging.Debug)
-#rogue.Logging.setFilter('pyrogue.protocols.packetizer.Application', rogue.Logging.Debug)
+#rogue.Logging.setFilter('pyrogue.packetizer', rogue.Logging.Debug)
+#rogue.Logging.setFilter('pyrogue.packetizer.Controller', rogue.Logging.Debug)
+#rogue.Logging.setFilter('pyrogue.packetizer.Application', rogue.Logging.Debug)
 #rogue.Logging.setLevel(rogue.Logging.Debug)
 
 


### PR DESCRIPTION
We have been experimenting with a lot of different amplifier configurations on physical boards.
This change provides modular amplifier models with a consistent interface for converting DAC and ADC units into physical values.

Note that #13 should be merged first, since this branch contains all of those changes.