### PR TITLE
Improved Front End Software Modeling (and other features)

### DIFF
--- a/firmware/common/warm_tdm/rtl/AdcDsp.vhd
+++ b/firmware/common/warm_tdm/rtl/AdcDsp.vhd
@@ -556,10 +556,11 @@ begin
 
                   -- First word is Column number
                   ssiSetUserSof(AXIS_DEBUG_CFG_C, v.pidDebugMaster, '1');
-                  v.pidDebugMaster.tValid             := v.pidDebugEnable;
-                  v.pidDebugMaster.tData(3 downto 0)  := toSlv(COLUMN_NUM_G, 4);
-                  v.pidDebugMaster.tData(15 downto 8) := v.rowIndex;
-                  v.state                             := WAIT_FIRST_SAMPLE_S;
+                  v.pidDebugMaster.tValid              := v.pidDebugEnable;
+                  v.pidDebugMaster.tData(3 downto 0)   := toSlv(COLUMN_NUM_G, 4);
+                  v.pidDebugMaster.tData(15 downto 8)  := v.rowIndex;
+                  v.pidDebugMaster.tData(63 downto 16) := timingRxData.runTime(47 downto 0);
+                  v.state                              := WAIT_FIRST_SAMPLE_S;
                end if;
 
 
@@ -601,7 +602,7 @@ begin
                v.pidCoef       := pSfixed;
                v.pidMultiplier := r.accumError;     -- Prep accumError for P stage
                v.pidResult     := (others => '0');  -- Clear pid result
-               v.state         := PID_P_S; --PID_PRESHIFT_S;
+               v.state         := PID_P_S;          --PID_PRESHIFT_S;
 
 --             when PID_PRESHIFT_S =>
 --                v.pidMultiplier := shift_right(r.pidMultiplier, to_integer(unsigned(r.accumShift)));
@@ -690,8 +691,8 @@ begin
 
       rin <= v;
 
-      pidStreamMaster.tValid                            <= r.sq1FbValid;
-      pidStreamMaster.tData(13 downto 0)                <= to_slv(r.sq1Fb);
+      pidStreamMaster.tValid                          <= r.sq1FbValid;
+      pidStreamMaster.tData(13 downto 0)              <= to_slv(r.sq1Fb);
       pidStreamMaster.tId(ROW_ADDR_BITS_C-1 downto 0) <= r.rowIndex;
 
       timingAxilWriteSlave <= r.axilWriteSlave;

--- a/firmware/common/warm_tdm/rtl/AdcDsp.vhd
+++ b/firmware/common/warm_tdm/rtl/AdcDsp.vhd
@@ -94,8 +94,8 @@ architecture rtl of AdcDsp is
 
    -- Max of 256 accumulations adds 8 bits to 14 bit ADC
    constant ACCUM_BITS_C : integer := 32;
-   constant COEF_HIGH_C  : integer := -1;
-   constant COEF_LOW_C   : integer := -24;
+   constant COEF_HIGH_C  : integer := 0;
+   constant COEF_LOW_C   : integer := -23;
    constant COEF_BITS_C  : integer := COEF_HIGH_C - COEF_LOW_C + 1;
 
    constant SUM_BITS_C    : integer := ACCUM_BITS_C;

--- a/firmware/common/warm_tdm/rtl/AdcDsp.vhd
+++ b/firmware/common/warm_tdm/rtl/AdcDsp.vhd
@@ -46,7 +46,7 @@ entity AdcDsp is
       -- AXI-Lite
 --       axilClk          : in  sl;
 --       timingRxRst125          : in  sl;
-      -- Local register access      
+      -- Local register access
       sAxilReadMaster  : in  AxiLiteReadMasterType;
       sAxilReadSlave   : out AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
       sAxilWriteMaster : in  AxiLiteWriteMasterType;
@@ -93,7 +93,7 @@ architecture rtl of AdcDsp is
 
 
    -- Max of 256 accumulations adds 8 bits to 14 bit ADC
-   constant ACCUM_BITS_C : integer := 32;
+   constant ACCUM_BITS_C : integer := 18;
    constant COEF_HIGH_C  : integer := 0;
    constant COEF_LOW_C   : integer := -23;
    constant COEF_BITS_C  : integer := COEF_HIGH_C - COEF_LOW_C + 1;
@@ -365,7 +365,7 @@ begin
          axiWriteSlave  => locAxilWriteSlaves(ACCUM_ERROR_C),   -- [out]
          clk            => timingRxClk125,                      -- [in]
          rst            => timingRxRst125,                      -- [in]
-         addr           => r.rowIndex,                          -- [in]         
+         addr           => r.rowIndex,                          -- [in]
          we             => r.accumValid,                        -- [in]
          din            => accumError,                          -- [in]
          dout           => accumRamOut);                        -- [in]
@@ -393,10 +393,10 @@ begin
          axiWriteSlave  => locAxilWriteSlaves(SUM_ACCUM_C),   -- [out]
          clk            => timingRxClk125,                    -- [in]
          rst            => timingRxRst125,                    -- [in]
-         addr           => r.rowIndex,                        -- [in]         
+         addr           => r.rowIndex,                        -- [in]
          we             => r.pidValid,                        -- [in]
          din            => sumAccum,                          -- [in]
-         dout           => sumRamOut);                        -- [in]   
+         dout           => sumRamOut);                        -- [in]
 
    pidResult <= to_slv(r.pidResult);
    U_AxiDualPortRam_PID_RESULTS : entity surf.AxiDualPortRam
@@ -420,7 +420,7 @@ begin
          axiWriteSlave  => locAxilWriteSlaves(PID_RESULTS_C),   -- [out]
          clk            => timingRxClk125,                      -- [in]
          rst            => timingRxRst125,                      -- [in]
-         addr           => r.rowIndex,                          -- [in]         
+         addr           => r.rowIndex,                          -- [in]
          we             => r.pidValid,                          -- [in]
          din            => pidResult,                           -- [in]
          dout           => pidRamOut);                          -- [in]
@@ -473,7 +473,7 @@ begin
          axiWriteSlave  => locAxilWriteSlaves(FILTER_RESULTS_C),                -- [out]
          clk            => timingRxClk125,                                      -- [in]
          rst            => timingRxRst125,                                      -- [in]
-         addr           => filterStreamMaster.tDest(7 downto 0),                -- [in]         
+         addr           => filterStreamMaster.tDest(7 downto 0),                -- [in]
          we             => filterStreamMaster.tValid,                           -- [in]
          din            => filterStreamMaster.tData(RESULT_BITS_C-1 downto 0),  -- [in]
          dout           => open);                                               -- [in]
@@ -806,7 +806,7 @@ begin
          axilWriteSlave  => mAxilWriteSlave,   -- [in]
          axilReadMaster  => mAxilReadMaster,   -- [out]
          axilReadSlave   => mAxilReadSlave);   -- [in]
-   -- 
+   --
    axilComb : process (ack, axilR, fifoDout, fifoValid, timingRxRst125) is
       variable v : AxilRegType := AXIL_REG_INIT_C;
    begin

--- a/firmware/common/warm_tdm/rtl/DataPath.vhd
+++ b/firmware/common/warm_tdm/rtl/DataPath.vhd
@@ -215,46 +215,48 @@ begin
 
 
    FIR_FILTER_GEN : for i in 7 downto 0 generate
---       U_FirFilterSingleChannel_1 : entity surf.FirFilterSingleChannel
---          generic map (
---             TPD_G            => TPD_G,
---             COMMON_CLK_G     => true,
---             NUM_TAPS_G       => 41,
---             SIDEBAND_WIDTH_G => 11+14,
---             DATA_WIDTH_G     => 16,
---             COEFF_WIDTH_G    => 26,
---             COEFFICIENTS_G   => FILTER_COEFFICIENTS_C)
---          port map (
---             clk                 => timingRxClk125,                             -- [in]
---             rst                 => timingRxRst125,                             -- [in]
---             ibValid             => adcStreams(i).tvalid,                       -- [in]
---             din                 => adcStreams(i).tData(15 downto 0),           -- [in]
---             sbIn(7 downto 0)    => timingRxData.rowIndex,                      -- [in]
---             sbIn(8)             => timingRxData.firstSample,                   -- [in]
---             sbIn(9)             => timingRxData.lastSample,                    -- [in]
---             sbIn(10)            => timingRxData.rowStrobe,                     -- [in]
---             sbIn(24 downto 11)  => sq1FbDacs(i),                               -- [in]
---             obValid             => filteredAdcStreams(i).tvalid,               -- [out]
---             dout                => filteredAdcStreams(i).tData(15 downto 0),   -- [out]
---             sbOut(7 downto 0)   => filteredAdcStreams(i).tid(7 downto 0),      -- [out]
---             sbOut(8)            => filteredAdcStreams(i).tUser(0),             -- [out]
---             sbOut(9)            => filteredAdcStreams(i).tUser(1),             -- [out]
---             sbOut(10)           => filteredAdcStreams(i).tUser(2),             -- [out]
---             sbOut(24 downto 11) => filteredAdcStreams(i).tData(29 downto 16),  -- [out]
---             axilClk             => timingRxClk125,                             -- [in]
---             axilRst             => timingRxRst125,                             -- [in]
---             axilReadMaster      => filterAxilReadMasters(i),                   -- [in]
---             axilReadSlave       => filterAxilReadSlaves(i),                    -- [out]
---             axilWriteMaster     => filterAxilWriteMasters(i),                  -- [in]
---             axilWriteSlave      => filterAxilWriteSlaves(i));                  -- [out]
+      U_FirFilterSingleChannel_1 : entity surf.FirFilterSingleChannel
+         generic map (
+            TPD_G            => TPD_G,
+            COMMON_CLK_G     => true,
+            NUM_TAPS_G       => 41,
+            SIDEBAND_WIDTH_G => 12+14,
+            DATA_WIDTH_G     => 16,
+            COEFF_WIDTH_G    => 26,
+            COEFFICIENTS_G   => FILTER_COEFFICIENTS_C)
+         port map (
+            clk                 => timingRxClk125,                             -- [in]
+            rst                 => timingRxRst125,                             -- [in]
+            ibValid             => adcStreams(i).tvalid,                       -- [in]
+            din                 => adcStreams(i).tData(15 downto 0),           -- [in]
+            sbIn(7 downto 0)    => timingRxData.rowIndex,                      -- [in]
+            sbIn(8)             => timingRxData.firstSample,                   -- [in]
+            sbIn(9)             => timingRxData.lastSample,                    -- [in]
+            sbIn(10)            => timingRxData.rowStrobe,                     -- [in]
+            sbIn(11)            => timingRxData.waveformCapture,               -- [in]            
+            sbIn(25 downto 12)  => sq1FbDacs(i),                               -- [in]
+            obValid             => filteredAdcStreams(i).tvalid,               -- [out]
+            dout                => filteredAdcStreams(i).tData(15 downto 0),   -- [out]
+            sbOut(7 downto 0)   => filteredAdcStreams(i).tid(7 downto 0),      -- [out]
+            sbOut(8)            => filteredAdcStreams(i).tUser(0),             -- [out]
+            sbOut(9)            => filteredAdcStreams(i).tUser(1),             -- [out]
+            sbOut(10)           => filteredAdcStreams(i).tUser(2),             -- [out]
+            sbOut(11)           => filteredAdcStreams(i).tUser(3),             -- [out]
+            sbOut(25 downto 12) => filteredAdcStreams(i).tData(29 downto 16),  -- [out]
+            axilClk             => timingRxClk125,                             -- [in]
+            axilRst             => timingRxRst125,                             -- [in]
+            axilReadMaster      => filterAxilReadMasters(i),                   -- [in]
+            axilReadSlave       => filterAxilReadSlaves(i),                    -- [out]
+            axilWriteMaster     => filterAxilWriteMasters(i),                  -- [in]
+            axilWriteSlave      => filterAxilWriteSlaves(i));                  -- [out]
 
-      filteredAdcStreams(i).tValid              <= adcStreams(i).tValid;
-      filteredAdcStreams(i).tData(15 downto 0)  <= adcStreams(i).tData(15 downto 0);
-      filteredAdcStreams(i).tid(7 downto 0)     <= timingRxData.rowIndex;
-      filteredAdcStreams(i).tuser(0)            <= timingRxData.firstSample;
-      filteredAdcStreams(i).tuser(1)            <= timingRxData.lastSample;
-      filteredAdcStreams(i).tuser(2)            <= timingRxData.rowStrobe;
-      filteredAdcStreams(i).tData(29 downto 16) <= sq1FbDacs(i);
+--       filteredAdcStreams(i).tValid              <= adcStreams(i).tValid;
+--       filteredAdcStreams(i).tData(15 downto 0)  <= adcStreams(i).tData(15 downto 0);
+--       filteredAdcStreams(i).tid(7 downto 0)     <= timingRxData.rowIndex;
+--       filteredAdcStreams(i).tuser(0)            <= timingRxData.firstSample;
+--       filteredAdcStreams(i).tuser(1)            <= timingRxData.lastSample;
+--       filteredAdcStreams(i).tuser(2)            <= timingRxData.rowStrobe;
+--       filteredAdcStreams(i).tData(29 downto 16) <= sq1FbDacs(i);
 
    end generate FIR_FILTER_GEN;
 
@@ -358,12 +360,12 @@ begin
          INPUT_PIPE_STAGES_G  => 0,
          OUTPUT_PIPE_STAGES_G => 0)
       port map (
-         axisClk     => axisClk,         -- [in]
-         axisRst     => axisRst,         -- [in]
-         sAxisMaster => dataAxisMaster,  -- [in]
-         sAxisSlave  => dataAxisSlave,   -- [out]
-         mAxisMaster => axisMaster,      -- [out]
-         mAxisSlave  => axisSlave);      -- [in]   
+         axisClk     => axisClk,              -- [in]
+         axisRst     => axisRst,              -- [in]
+         sAxisMaster => dataAxisMaster,       -- [in]
+         sAxisSlave  => dataAxisSlave,        -- [out]
+         mAxisMaster => axisMaster,           -- [out]
+         mAxisSlave  => axisSlave);           -- [in]   
 
 
    -- Combine Sq1 masters into single bus

--- a/firmware/common/warm_tdm/rtl/PgpEthCore.vhd
+++ b/firmware/common/warm_tdm/rtl/PgpEthCore.vhd
@@ -40,6 +40,7 @@ entity PgpEthCore is
    generic (
       TPD_G                   : time             := 1 ns;
       SIMULATION_G            : boolean          := false;
+      SIMULATE_PGP_G          : boolean          := true;
       SIM_PGP_PORT_NUM_G      : integer          := 7000;
       SIM_ETH_SRP_PORT_NUM_G  : integer          := 8000;
       SIM_ETH_DATA_PORT_NUM_G : integer          := 9000;
@@ -166,42 +167,44 @@ begin
    -----------------
    -- PGP Interface
    -----------------
-   U_PgpCore_1 : entity warm_tdm.PgpCore
-      generic map (
-         TPD_G            => TPD_G,
-         SIMULATION_G     => SIMULATION_G,
-         SIM_PORT_NUM_G   => SIM_PGP_PORT_NUM_G,
-         REF_CLK_FREQ_G   => REF_CLK_FREQ_G,
-         RING_ADDR_0_G    => RING_ADDR_0_G,
-         AXIL_BASE_ADDR_G => AXIL_BASE_ADDR_G)
-      port map (
-         refRst           => refRst,                            -- [in]
-         gtRefClk         => gtRefClk,                          -- [in]
-         fabRefClk        => fabRefClk,                         -- [in]
-         pgpTxP           => pgpTxP,                            -- [out]
-         pgpTxN           => pgpTxN,                            -- [out]
-         pgpRxP           => pgpRxP,                            -- [in]
-         pgpRxN           => pgpRxN,                            -- [in]
-         pgpTxLink        => pgpTxLink,                         -- [out]
-         pgpRxLink        => pgpRxLink,                         -- [out]
-         axiClk           => axilClk,                           -- [out]
-         axiRst           => axilRst,                           -- [out]
-         mAxilReadMaster  => mLocAxilReadMasters(AXIL_PGP_C),   -- [out]
-         mAxilReadSlave   => mLocAxilReadSlaves(AXIL_PGP_C),    -- [in]
-         mAxilWriteMaster => mLocAxilWriteMasters(AXIL_PGP_C),  -- [out]
-         mAxilWriteSlave  => mLocAxilWriteSlaves(AXIL_PGP_C),   -- [in]
-         sAxilReadMaster  => sLocAxilReadMasters(AXIL_PGP_C),   -- [in]
-         sAxilReadSlave   => sLocAxilReadSlaves(AXIL_PGP_C),    -- [out]
-         sAxilWriteMaster => sLocAxilWriteMasters(AXIL_PGP_C),  -- [in]
-         sAxilWriteSlave  => sLocAxilWriteSlaves(AXIL_PGP_C),   -- [out]
-         ethRxAxisMasters => ethRemoteRxAxisMasters,            -- [in]
-         ethRxAxisSlaves  => ethRemoteRxAxisSlaves,             -- [out]
-         ethTxAxisMasters => ethRemoteTxAxisMasters,            -- [out]
-         ethTxAxisSlaves  => ethRemoteTxAxisSlaves,             -- [in]
-         dataTxAxisMaster => pgpDataTxAxisMaster,               -- [in]
-         dataTxAxisSlave  => pgpDataTxAxisSlave,                -- [out]
-         dataRxAxisMaster => pgpDataRxAxisMaster,               -- [out]
-         dataRxAxisSlave  => pgpDataRxAxisSlave);               -- [in]
+   GEN_PGP : if (not (SIMULATION_G and SIMULATE_PGP_G)) generate
+      U_PgpCore_1 : entity warm_tdm.PgpCore
+         generic map (
+            TPD_G            => TPD_G,
+            SIMULATION_G     => SIMULATION_G,
+            SIM_PORT_NUM_G   => SIM_PGP_PORT_NUM_G,
+            REF_CLK_FREQ_G   => REF_CLK_FREQ_G,
+            RING_ADDR_0_G    => RING_ADDR_0_G,
+            AXIL_BASE_ADDR_G => AXIL_BASE_ADDR_G)
+         port map (
+            refRst           => refRst,                            -- [in]
+            gtRefClk         => gtRefClk,                          -- [in]
+            fabRefClk        => fabRefClk,                         -- [in]
+            pgpTxP           => pgpTxP,                            -- [out]
+            pgpTxN           => pgpTxN,                            -- [out]
+            pgpRxP           => pgpRxP,                            -- [in]
+            pgpRxN           => pgpRxN,                            -- [in]
+            pgpTxLink        => pgpTxLink,                         -- [out]
+            pgpRxLink        => pgpRxLink,                         -- [out]
+            axiClk           => axilClk,                           -- [out]
+            axiRst           => axilRst,                           -- [out]
+            mAxilReadMaster  => mLocAxilReadMasters(AXIL_PGP_C),   -- [out]
+            mAxilReadSlave   => mLocAxilReadSlaves(AXIL_PGP_C),    -- [in]
+            mAxilWriteMaster => mLocAxilWriteMasters(AXIL_PGP_C),  -- [out]
+            mAxilWriteSlave  => mLocAxilWriteSlaves(AXIL_PGP_C),   -- [in]
+            sAxilReadMaster  => sLocAxilReadMasters(AXIL_PGP_C),   -- [in]
+            sAxilReadSlave   => sLocAxilReadSlaves(AXIL_PGP_C),    -- [out]
+            sAxilWriteMaster => sLocAxilWriteMasters(AXIL_PGP_C),  -- [in]
+            sAxilWriteSlave  => sLocAxilWriteSlaves(AXIL_PGP_C),   -- [out]
+            ethRxAxisMasters => ethRemoteRxAxisMasters,            -- [in]
+            ethRxAxisSlaves  => ethRemoteRxAxisSlaves,             -- [out]
+            ethTxAxisMasters => ethRemoteTxAxisMasters,            -- [out]
+            ethTxAxisSlaves  => ethRemoteTxAxisSlaves,             -- [in]
+            dataTxAxisMaster => pgpDataTxAxisMaster,               -- [in]
+            dataTxAxisSlave  => pgpDataTxAxisSlave,                -- [out]
+            dataRxAxisMaster => pgpDataRxAxisMaster,               -- [out]
+            dataRxAxisSlave  => pgpDataRxAxisSlave);               -- [in]
+   end generate GEN_PGP;
 
    ---------------------
    -- Ethernet Interfacepcie

--- a/firmware/common/warm_tdm/rtl/TimingPkg.vhd
+++ b/firmware/common/warm_tdm/rtl/TimingPkg.vhd
@@ -39,42 +39,42 @@ package TimingPkg is
    constant SAMPLE_START_C : slv(7 downto 0) := "10011100";  -- K28.4
    constant SAMPLE_END_C   : slv(7 downto 0) := "11011100";  -- K28.6
    constant LOAD_DACS_C    : slv(7 downto 0) := "11110111";  -- K23.7
-   constant RAW_ADC_C      : slv(7 downto 0) := "11111110";  -- K30.7
+   constant WAVEFORM_CAPTURE_C      : slv(7 downto 0) := "11111110";  -- K30.7
 
    type LocalTimingType is record
-      startRun     : sl;                -- Strobed at start of run
-      endRun       : sl;                -- Strobed at end of run
-      running      : sl;                -- Set high during run
-      runTime      : slv(63 downto 0);  -- TimingClk counts since start of run
-      rowStrobe    : sl;                -- Moving to new row
-      sample       : sl;
-      firstSample  : sl;
-      lastSample   : sl;
-      loadDacs     : sl;
-      rowSeq       : slv(7 downto 0);   -- Sequence in row readout list
-      rowIndex     : slv(7 downto 0);   -- Current row index
-      rowIndexNext : slv(7 downto 0);   -- Next row index
-      rowTime      : slv(31 downto 0);  -- timingClk counts since last row strobe
-      readoutCount : slv(63 downto 0);  -- Number of full loops through all rows
-      rawAdc       : sl;                -- Capture ADC waveforms on all channels
+      startRun        : sl;                -- Strobed at start of run
+      endRun          : sl;                -- Strobed at end of run
+      running         : sl;                -- Set high during run
+      runTime         : slv(63 downto 0);  -- TimingClk counts since start of run
+      rowStrobe       : sl;                -- Moving to new row
+      sample          : sl;
+      firstSample     : sl;
+      lastSample      : sl;
+      loadDacs        : sl;
+      rowSeq          : slv(7 downto 0);   -- Sequence in row readout list
+      rowIndex        : slv(7 downto 0);   -- Current row index
+      rowIndexNext    : slv(7 downto 0);   -- Next row index
+      rowTime         : slv(31 downto 0);  -- timingClk counts since last row strobe
+      readoutCount    : slv(63 downto 0);  -- Number of full loops through all rows
+      waveformCapture : sl;                -- Capture ADC waveforms on all channels
    end record LocalTimingType;
 
    constant LOCAL_TIMING_INIT_C : LocalTimingType := (
-      startRun     => '0',
-      endRun       => '0',
-      running      => '0',
-      runTime      => (others => '0'),
-      rowStrobe    => '0',
-      sample       => '0',
-      firstSample  => '0',
-      lastSample   => '0',
-      loadDacs     => '0',
-      rowSeq       => (others => '0'),
-      rowIndex     => (others => '0'),
-      rowIndexNext => (others => '0'),
-      rowTime      => (others => '0'),
-      readoutCount => (others => '0'),
-      rawAdc       => '0');
+      startRun        => '0',
+      endRun          => '0',
+      running         => '0',
+      runTime         => (others => '0'),
+      rowStrobe       => '0',
+      sample          => '0',
+      firstSample     => '0',
+      lastSample      => '0',
+      loadDacs        => '0',
+      rowSeq          => (others => '0'),
+      rowIndex        => (others => '0'),
+      rowIndexNext    => (others => '0'),
+      rowTime         => (others => '0'),
+      readoutCount    => (others => '0'),
+      waveformCapture => '0');
 
 
 end package TimingPkg;

--- a/firmware/common/warm_tdm/rtl/TimingRx.vhd
+++ b/firmware/common/warm_tdm/rtl/TimingRx.vhd
@@ -472,22 +472,22 @@ begin
          CNT_WIDTH_G    => 16,
          WIDTH_G        => 8)
       port map (
-         statusIn(0)  => locked,                      -- [in]
-         statusIn(1)  => errorDet,                    -- [in]
-         statusIn(2)  => r.timingRxData.startRun,     -- [in]
-         statusIn(3)  => r.timingRxData.endRun,       -- [in]
-         statusIn(4)  => r.timingRxData.rowStrobe,    -- [in]
-         statusIn(5)  => r.timingRxData.firstSample,  -- [in]
-         statusIn(6)  => r.timingRxData.lastSample,   -- [in]
-         statusIn(7)  => r.timingRxData.rawAdc,       -- [in]
-         statusOut    => statusVector,                -- [out]
-         cntRstIn     => axilR.counterReset,          -- [in]
-         rollOverEnIn => "01110000",                  -- [in]
-         cntOut       => counterVector,               -- [out]
-         wrClk        => wordClk,                     -- [in]
-         wrRst        => wordRst,                     -- [in]
-         rdClk        => axilClk,                     -- [in]
-         rdRst        => axilRst);                    -- [in]
+         statusIn(0)  => locked,                          -- [in]
+         statusIn(1)  => errorDet,                        -- [in]
+         statusIn(2)  => r.timingRxData.startRun,         -- [in]
+         statusIn(3)  => r.timingRxData.endRun,           -- [in]
+         statusIn(4)  => r.timingRxData.rowStrobe,        -- [in]
+         statusIn(5)  => r.timingRxData.firstSample,      -- [in]
+         statusIn(6)  => r.timingRxData.lastSample,       -- [in]
+         statusIn(7)  => r.timingRxData.waveformCapture,  -- [in]
+         statusOut    => statusVector,                    -- [out]
+         cntRstIn     => axilR.counterReset,              -- [in]
+         rollOverEnIn => "01110000",                      -- [in]
+         cntOut       => counterVector,                   -- [out]
+         wrClk        => wordClk,                         -- [in]
+         wrRst        => wordRst,                         -- [in]
+         rdClk        => axilClk,                         -- [in]
+         rdRst        => axilRst);                        -- [in]
 
    U_AxiLiteCrossbar_1 : entity surf.AxiLiteCrossbar
       generic map (
@@ -528,13 +528,13 @@ begin
          v.timingRxData.rowTime := r.timingRxData.rowTime + 1;
       end if;
 
-      v.timingRxData.startRun    := '0';
-      v.timingRxData.endRun      := '0';
-      v.timingRxData.rowStrobe   := '0';
-      v.timingRxData.firstSample := '0';
-      v.timingRxData.lastSample  := '0';
-      v.timingRxData.loadDacs    := '0';
-      v.timingRxData.rawAdc      := '0';
+      v.timingRxData.startRun        := '0';
+      v.timingRxData.endRun          := '0';
+      v.timingRxData.rowStrobe       := '0';
+      v.timingRxData.firstSample     := '0';
+      v.timingRxData.lastSample      := '0';
+      v.timingRxData.loadDacs        := '0';
+      v.timingRxData.waveformCapture := '0';
 
 --      v.nextRowSeq := r.timingRxData.rowSeq + 1;
 
@@ -570,8 +570,8 @@ begin
                v.timingRxData.lastSample := '1';
             when LOAD_DACS_C =>
                v.timingRxData.loadDacs := '1';
-            when RAW_ADC_C =>
-               v.timingRxData.rawAdc := '1';
+            when WAVEFORM_CAPTURE_C =>
+               v.timingRxData.waveformCapture := '1';
             when others => null;
          end case;
       end if;

--- a/firmware/common/warm_tdm/rtl/TimingTx.vhd
+++ b/firmware/common/warm_tdm/rtl/TimingTx.vhd
@@ -83,39 +83,41 @@ architecture rtl of TimingTx is
       xbarTimingSel : slv(1 downto 0);
 
       -- Config
-      runMode           : sl;
-      softwareRowStrobe : sl;
-      rowPeriod         : slv(31 downto 0);
-      numRows           : slv(15 downto 0);
-      sampleStartTime   : slv(31 downto 0);
-      sampleEndTime     : slv(31 downto 0);
-      loadDacsTime      : slv(31 downto 0);
+      runMode             : sl;
+      softwareRowStrobe   : sl;
+      rowPeriod           : slv(31 downto 0);
+      numRows             : slv(15 downto 0);
+      sampleStartTime     : slv(31 downto 0);
+      sampleEndTime       : slv(31 downto 0);
+      loadDacsTime        : slv(31 downto 0);
+      waveformCaptureTime : slv(31 downto 0);
       -- State
-      timingData        : LocalTimingType;
-      timingTx          : slv(7 downto 0);
-      timingTxK         : slv(0 downto 0);
+      timingData          : LocalTimingType;
+      timingTx            : slv(7 downto 0);
+      timingTxK           : slv(0 downto 0);
       -- AXIL
-      axilWriteSlave    : AxiLiteWriteSlaveType;
-      axilReadSlave     : AxiLiteReadSlaveType;
+      axilWriteSlave      : AxiLiteWriteSlaveType;
+      axilReadSlave       : AxiLiteReadSlaveType;
    end record RegType;
 
    constant REG_INIT_C : RegType := (
-      xbarDataSel       => ite(RING_ADDR_0_G, "11", "00"),  -- Temporary loopback only
-      xbarClkSel        => ite(RING_ADDR_0_G, "11", "00"),
-      xbarMgtSel        => "01",
-      xbarTimingSel     => "01",
-      runMode           => SOFTWARE_C,
-      softwareRowStrobe => '0',
-      rowPeriod         => toSlv(250, 32),                  -- 125 MHz / 256 = 488 kHz
-      numRows           => toSlv(256, 16),                  -- Default of 64 rows
-      sampleStartTime   => toSlv(32, 32),
-      sampleEndTime     => toSlv(160, 32),                  -- Could be corner case here?
-      loadDacsTime      => toSlv(200, 32),
-      timingTx          => IDLE_C,
-      timingTxK         => "1",
-      timingData        => LOCAL_TIMING_INIT_C,
-      axilWriteSlave    => AXI_LITE_WRITE_SLAVE_INIT_C,
-      axilReadSlave     => AXI_LITE_READ_SLAVE_INIT_C);
+      xbarDataSel         => ite(RING_ADDR_0_G, "11", "00"),  -- Temporary loopback only
+      xbarClkSel          => ite(RING_ADDR_0_G, "11", "00"),
+      xbarMgtSel          => "01",
+      xbarTimingSel       => "01",
+      runMode             => SOFTWARE_C,
+      softwareRowStrobe   => '0',
+      rowPeriod           => toSlv(250, 32),                  -- 125 MHz / 256 = 488 kHz
+      numRows             => toSlv(256, 16),                  -- Default of 64 rows
+      sampleStartTime     => toSlv(32, 32),
+      sampleEndTime       => toSlv(160, 32),                  -- Could be corner case here?
+      loadDacsTime        => toSlv(200, 32),
+      waveformCaptureTime => toSlv(1, 32),
+      timingTx            => IDLE_C,
+      timingTxK           => "1",
+      timingData          => LOCAL_TIMING_INIT_C,
+      axilWriteSlave      => AXI_LITE_WRITE_SLAVE_INIT_C,
+      axilReadSlave       => AXI_LITE_READ_SLAVE_INIT_C);
 
    signal r   : RegType := REG_INIT_C;
    signal rin : RegType;
@@ -218,8 +220,6 @@ begin
 
       -- Strobed signals
       v.softwareRowStrobe := '0';
-      v.timingData.rawAdc := '0';
-
 
       -- Configuration
       axiSlaveRegister(axilEp, X"00", 0, v.timingData.startRun);
@@ -231,8 +231,9 @@ begin
       axiSlaveRegister(axilEp, X"18", 0, v.runMode);
       axiSlaveRegister(axilEp, X"1C", 0, v.softwareRowStrobe);
 
-      axiSlaveRegister(axilEp, X"20", 0, v.timingData.rawAdc);
+      axiSlaveRegister(axilEp, X"20", 0, v.timingData.waveformCapture);
       axiSlaveRegister(axilEp, X"24", 0, v.loadDacsTime);
+      axiSlaveRegister(axilEp, X"28", 0, v.waveformCaptureTime);
 
       -- Status
       axiSlaveRegisterR(axilEp, X"30", 0, r.timingData.running);
@@ -266,8 +267,9 @@ begin
 
       v.timingData.rowStrobe := '0';
 
-      if (r.timingData.rawAdc = '1') then
-         v.timingTx := RAW_ADC_C;
+      if (r.timingData.waveformCapture = '1' and r.waveformCaptureTime = r.timingData.rowTime) then
+         v.timingTx                   := WAVEFORM_CAPTURE_C;
+         v.timingData.waveformCapture := '0';
       end if;
 
       -- Start run
@@ -278,15 +280,15 @@ begin
          v.timingData.rowTime      := (others => '0');
          v.timingData.readoutCount := (others => '0');
 
-         v.timingTx                := START_RUN_C;
+         v.timingTx := START_RUN_C;
       end if;
 
 
       if (r.timingData.running = '1') then
-         v.timingData.startRun     := '0';         
+         v.timingData.startRun := '0';
          -- Count the things
-         v.timingData.runTime := r.timingData.runTime + 1;
-         v.timingData.rowTime := r.timingData.rowTime + 1;
+         v.timingData.runTime  := r.timingData.runTime + 1;
+         v.timingData.rowTime  := r.timingData.rowTime + 1;
 
          if ((r.runMode = HARDWARE_C and r.timingData.rowTime = r.rowPeriod-1) or
              (r.runMode = SOFTWARE_C and r.softwareRowStrobe = '1')) then

--- a/firmware/common/warm_tdm/rtl/TimingTx.vhd
+++ b/firmware/common/warm_tdm/rtl/TimingTx.vhd
@@ -112,7 +112,7 @@ architecture rtl of TimingTx is
       sampleStartTime     => toSlv(32, 32),
       sampleEndTime       => toSlv(160, 32),                  -- Could be corner case here?
       loadDacsTime        => toSlv(200, 32),
-      waveformCaptureTime => toSlv(1, 32),
+      waveformCaptureTime => toSlv(2, 32),
       timingTx            => IDLE_C,
       timingTxK           => "1",
       timingData          => LOCAL_TIMING_INIT_C,

--- a/firmware/common/warm_tdm/rtl/WarmTdmCore.vhd
+++ b/firmware/common/warm_tdm/rtl/WarmTdmCore.vhd
@@ -37,6 +37,7 @@ entity WarmTdmCore is
    generic (
       TPD_G                   : time                     := 1 ns;
       SIMULATION_G            : boolean                  := false;
+      SIMULATE_PGP_G          : boolean                  := true;
       SIM_PGP_PORT_NUM_G      : integer                  := 7000;
       SIM_ETH_SRP_PORT_NUM_G  : integer                  := 8000;
       SIM_ETH_DATA_PORT_NUM_G : integer                  := 9000;
@@ -324,7 +325,7 @@ begin
          timingRxClkOut  => locTimingRxClk125,                   -- [out]
          timingRxRstOut  => timingRxRst125,                      -- [out]
          timingRxDataOut => timingRxData,   -- [out]
-         timingRxLocked  => timingRxLocked, -- [out]
+         timingRxLocked  => timingRxLocked,                      -- [out]
          timingTxClkP    => timingTxClkP,   -- [out]
          timingTxClkN    => timingTxClkN,   -- [out]
          timingTxDataP   => timingTxDataP,  -- [out]
@@ -347,6 +348,7 @@ begin
       generic map (
          TPD_G                   => TPD_G,
          SIMULATION_G            => SIMULATION_G,
+         SIMULATE_PGP_G          => SIMULATE_PGP_G,
          SIM_PGP_PORT_NUM_G      => SIM_PGP_PORT_NUM_G,
          SIM_ETH_SRP_PORT_NUM_G  => SIM_ETH_SRP_PORT_NUM_G,
          SIM_ETH_DATA_PORT_NUM_G => SIM_ETH_DATA_PORT_NUM_G,

--- a/firmware/common/warm_tdm/rtl/WaveformCapture.vhd
+++ b/firmware/common/warm_tdm/rtl/WaveformCapture.vhd
@@ -268,7 +268,7 @@ begin
       -- Dump data info FIFO when triggered
       -- Multiplex combined or resized channel streams
       ----------------------------------------------------------------------------------------------
-      if (timingRxData.waveformCapture = '1' or r.waveformTrigger = '1') then
+      if ((adcStreams(0).tValid = '1' and adcStreams(0).tUser(3) = '1') or r.waveformTrigger = '1') then
          v.doWaveform                       := '1';
          v.bufferStream.tValid              := '1';
          v.bufferStream.tData(2 downto 0)   := r.selectedChannel;

--- a/firmware/common/warm_tdm/rtl/WaveformCapture.vhd
+++ b/firmware/common/warm_tdm/rtl/WaveformCapture.vhd
@@ -94,6 +94,7 @@ architecture rtl of WaveformCapture is
    type RegType is record
       reset            : sl;
       average          : slv32Array(7 downto 0);
+      sample           : slv16Array(7 downto 0);
       alpha            : slv(3 downto 0);
       pauseThresh      : slv(13 downto 0);
       waveformTrigger  : sl;
@@ -113,6 +114,7 @@ architecture rtl of WaveformCapture is
    constant REG_INIT_C : RegType := (
       reset            => '0',
       average          => (others => (others => '0')),
+      sample           => (others => (others => '0')),
       alpha            => toSlv(15, 4),
       pauseThresh      => toSlv(2**14-8, 14),
       waveformTrigger  => '0',
@@ -195,6 +197,16 @@ begin
       axiSlaveRegisterR(axilEp, X"28", 0, r.average(6));
       axiSlaveRegisterR(axilEp, X"2C", 0, r.average(7));
 
+      axiSlaveRegisterR(axilEp, X"30", 0, r.sample(0));
+      axiSlaveRegisterR(axilEp, X"34", 0, r.sample(1));
+      axiSlaveRegisterR(axilEp, X"38", 0, r.sample(2));
+      axiSlaveRegisterR(axilEp, X"3C", 0, r.sample(3));
+      axiSlaveRegisterR(axilEp, X"40", 0, r.sample(4));
+      axiSlaveRegisterR(axilEp, X"44", 0, r.sample(5));
+      axiSlaveRegisterR(axilEp, X"48", 0, r.sample(6));
+      axiSlaveRegisterR(axilEp, X"4C", 0, r.sample(7));
+      
+
       axiSlaveDefault(axilEp, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
 
       ----------------------------------------------------------------------------------------------
@@ -206,13 +218,16 @@ begin
             average      := signed(r.average(i));
             avgDiv       := shift_right(average, alpha);
             sample       := resize(signed(adcStreams(i).tData(15 downto 0)), 32);
+            v.sample(i)  := adcStreams(i).tData(15 downto 0);
             sample       := shift_right(shift_left(sample, 16), alpha);
             average      := average - avgDiv + sample;
             v.average(i) := slv(average);
+
          end loop;
       end if;
       if (r.reset = '1') then
          v.average := (others => (others => '0'));
+         v.sample := (others => (others => '0'));         
       end if;
 
 
@@ -253,7 +268,7 @@ begin
       -- Dump data info FIFO when triggered
       -- Multiplex combined or resized channel streams
       ----------------------------------------------------------------------------------------------
-      if (timingRxData.rawAdc = '1' or r.waveformTrigger = '1') then
+      if (timingRxData.waveformCapture = '1' or r.waveformTrigger = '1') then
          v.doWaveform                       := '1';
          v.bufferStream.tValid              := '1';
          v.bufferStream.tData(2 downto 0)   := r.selectedChannel;

--- a/firmware/common/warm_tdm/sim/Ad5679R.vhd
+++ b/firmware/common/warm_tdm/sim/Ad5679R.vhd
@@ -152,7 +152,7 @@ begin
                v.ldacMask := data;
 
             when SOFT_RST_CMD_C =>
-               if (addr = X"0" and data = X"1234") then
+               if (addr = 0 and data = X"1234") then
                   v := REG_INIT_C;
                end if;
 

--- a/firmware/common/warm_tdm/sim/Ad9767.vhd
+++ b/firmware/common/warm_tdm/sim/Ad9767.vhd
@@ -33,7 +33,7 @@ entity Ad9767 is
       iqsel   : in  sl;
       iqwrt   : in  sl;
       iqclk   : in  sl;
-      iqreset : in  sl;
+      iqreset : in  sl := '0';
       iOut1A  : out real;
       iOut1B  : out real;
       iOut2A  : out real;

--- a/firmware/python/warm_tdm/_Ad5679R.py
+++ b/firmware/python/warm_tdm/_Ad5679R.py
@@ -1,4 +1,5 @@
 import pyrogue as pr
+import numpy as np
 
 class Ad5679R(pr.Device):
     def __init__(self, gain=1, **kwargs):
@@ -66,13 +67,11 @@ class Ad5679R(pr.Device):
         @self.command()
         def ZeroVoltages():
             self.setVoltages(list(range(16)), [0 for x in range(16)])
-            
+
 
     def _setVoltageFunc(self, chVar):
         def _setVoltage(value, write):
-            if 0 > value > self.gain * 2.5:
-                raise VariableError(f'Tried to set DAC voltage {value} outside of range 0 - {self.gain*2.5}')
-
+            value = np.clip(value, 0.0, 2.499)
             dacValue = int(round((value / (self.gain * 2.5)) * 2**16))
             chVar.set(value=dacValue, write=write)
 
@@ -100,6 +99,3 @@ class Ad5679R(pr.Device):
         # For display only
         for ch, v in zip(channels, voltages):
             self.DacVoltage[ch].set(v, write=True)
-        
-
-

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -71,12 +71,14 @@ class AdcDsp(pr.Device):
     def __init__(self, column, numRows=256, **kwargs):
         super().__init__(**kwargs)
 
-        ACCUM_BITS = 22
+        ACCUM_BITS = 32
 #        COEF_BITS = 10
 #        SUM_BITS = 18
-        RESULT_BITS = 32
+        RESULT_BITS = 56
 
-        COEF_BASE = pr.Fixed(18, 17)
+        COEF_BASE = pr.Fixed(24, 24)
+        ACCUM_BASE = pr.Fixed(32, 0)
+        RESULT_BASE = pr.Fixed(56, 24)
 
         numRows = 4
 
@@ -158,32 +160,32 @@ class AdcDsp(pr.Device):
             name = 'AccumError_DBG',
             mode = 'RO',
             offset = 0x10,
-            base = pr.Fixed(22, 0),
-            bitSize = 22,
+            base = ACCUM_BASE,
+            bitSize = 32,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'LastAccum_DBG',
             mode = 'RO',
             offset = 0x14,
-            base = pr.Fixed(22, 0),
-            bitSize = 22,
+            base = ACCUM_BASE,
+            bitSize = 32,
             bitOffset = 0))
         
         self.add(pr.RemoteVariable(
             name = 'SumAccum_DBG',
             mode = 'RO',
             offset = 0x18,
-            base = pr.Fixed(22, 0),
-            bitSize = 22,
+            base = ACCUM_BASE,
+            bitSize = 32,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'PidResult_DBG',
             mode = 'RO',
             offset = 0x20,
-            base = pr.Fixed(40, 17),
-            bitSize = 40,
+            base = RESULT_BASE,
+            bitSize = 56,
             bitOffset = 0))
         
         self.add(pr.RemoteVariable(

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -76,9 +76,9 @@ class AdcDsp(pr.Device):
 #        SUM_BITS = 18
         RESULT_BITS = 56
 
-        COEF_BASE = pr.Fixed(24, 24)
+        COEF_BASE = pr.Fixed(24, 23)
         ACCUM_BASE = pr.Fixed(32, 0)
-        RESULT_BASE = pr.Fixed(56, 24)
+        RESULT_BASE = pr.Fixed(56, 23)
 
         numRows = 4
 
@@ -104,21 +104,21 @@ class AdcDsp(pr.Device):
             name = 'P_Coef',
             offset = 0x04,
             base = COEF_BASE,
-            bitSize = 18,
+            bitSize = 24,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'I_Coef',
             offset = 0x08,
             base = COEF_BASE,
-            bitSize = 18,
+            bitSize = 24,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'D_Coef',
             offset = 0x0C,
             base = COEF_BASE,
-            bitSize = 18,
+            bitSize = 24,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -79,14 +79,29 @@ class AdcDsp(pr.Device):
         self.amp = frontEnd.Channel[column].SQ1FbAmp
 
         self.add(pr.RemoteVariable(
-            name = 'PidEnable',
+            name = 'PidEnableRaw',
             offset = 0x00,
             base = pr.Bool,
+            hidden = True,
+            groups = ['NoConfig'],
             mode = 'RW',
             bitSize = 1,
             bitOffset = 0))
 
+        def _enablePid(value, write):
+            self.ClearPids()
+            self.PidEnableRaw.set(value, write)
 
+        self.add(pr.LinkVariable(
+            name = 'PidEnable',
+            groups = ['NoConfig'],
+            base = pr.Bool,
+            enum = {
+                False: 'False',
+                True: 'True'},
+            dependencies = [self.PidEnableRaw],
+            linkedSet = _enablePid,
+            linkedGet = self.PidEnableRaw.get))
 
         self.add(pr.RemoteVariable(
             name = 'P_Coef',

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -77,6 +77,7 @@ class AdcDsp(pr.Device):
         super().__init__(**kwargs)
 
         self.amp = frontEnd.Channel[column].SQ1FbAmp
+        self.rows = rows
 
         self.add(pr.RemoteVariable(
             name = 'PidEnableRaw',
@@ -273,7 +274,7 @@ class AdcDsp(pr.Device):
 
         @self.command()
         def ClearPids():
-            blank = [0 for x in range(numRows)]
+            blank = [0 for x in range(self.rows)]
             self.SumAccum.set(blank)
             self.PidResults.set(blank)
             self.FluxJumps.set(blank)

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -69,14 +69,9 @@ class RowPidStatusArray(pr.Device):
 
 class AdcDsp(pr.Device):
     
-    ACCUM_BITS = 32
-#        COEF_BITS = 10
-#        SUM_BITS = 18
-    RESULT_BITS = 56
-
     COEF_BASE = pr.Fixed(24, 23)
-    ACCUM_BASE = pr.Fixed(32, 0)
-    RESULT_BASE = pr.Fixed(56, 23)
+    ACCUM_BASE = pr.Fixed(18, 0)
+    RESULT_BASE = pr.Fixed(48, 23)
         
     def __init__(self, frontEnd, column, numRows=256, **kwargs):
         super().__init__(**kwargs)

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -68,17 +68,20 @@ class RowPidStatusArray(pr.Device):
                 rowNum = row))
 
 class AdcDsp(pr.Device):
+    
+    ACCUM_BITS = 32
+#        COEF_BITS = 10
+#        SUM_BITS = 18
+    RESULT_BITS = 56
+
+    COEF_BASE = pr.Fixed(24, 23)
+    ACCUM_BASE = pr.Fixed(32, 0)
+    RESULT_BASE = pr.Fixed(56, 23)
+        
     def __init__(self, frontEnd, column, numRows=256, **kwargs):
         super().__init__(**kwargs)
 
-        ACCUM_BITS = 32
-#        COEF_BITS = 10
-#        SUM_BITS = 18
-        RESULT_BITS = 56
 
-        COEF_BASE = pr.Fixed(24, 23)
-        ACCUM_BASE = pr.Fixed(32, 0)
-        RESULT_BASE = pr.Fixed(56, 23)
 
         numRows = 4
 
@@ -97,22 +100,22 @@ class AdcDsp(pr.Device):
         self.add(pr.RemoteVariable(
             name = 'P_Coef',
             offset = 0x04,
-            base = COEF_BASE,
-            bitSize = 24,
+            base = AdcDsp.COEF_BASE,
+            bitSize = AdcDsp.COEF_BASE.bitSize,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'I_Coef',
             offset = 0x08,
-            base = COEF_BASE,
-            bitSize = 24,
+            base = AdcDsp.COEF_BASE,
+            bitSize = AdcDsp.COEF_BASE.bitSize,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'D_Coef',
             offset = 0x0C,
-            base = COEF_BASE,
-            bitSize = 24,
+            base = AdcDsp.COEF_BASE,
+            bitSize = AdcDsp.COEF_BASE.bitSize,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
@@ -162,32 +165,32 @@ class AdcDsp(pr.Device):
             name = 'AccumError_DBG',
             mode = 'RO',
             offset = 0x10,
-            base = ACCUM_BASE,
-            bitSize = 32,
+            base = AdcDsp.ACCUM_BASE,
+            bitSize = AdcDsp.ACCUM_BASE.bitSize,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'LastAccum_DBG',
             mode = 'RO',
             offset = 0x14,
-            base = ACCUM_BASE,
-            bitSize = 32,
+            base = AdcDsp.ACCUM_BASE,
+            bitSize = AdcDsp.ACCUM_BASE.bitSize,
             bitOffset = 0))
         
         self.add(pr.RemoteVariable(
             name = 'SumAccum_DBG',
             mode = 'RO',
             offset = 0x18,
-            base = ACCUM_BASE,
-            bitSize = 32,
+            base = AdcDsp.ACCUM_BASE,
+            bitSize = AdcDsp.ACCUM_BASE.bitSize,
             bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'PidResult_DBG',
             mode = 'RO',
             offset = 0x20,
-            base = RESULT_BASE,
-            bitSize = 56,
+            base = AdcDsp.RESULT_BASE,
+            bitSize = AdcDsp.RESULT_BASE.bitSize,
             bitOffset = 0))
         
         self.add(pr.RemoteVariable(
@@ -204,7 +207,6 @@ class AdcDsp(pr.Device):
             offset = 0x1000,
             base = pr.Int,
             mode = 'RW',
-#            bitSize = 32*numRows,
             numValues = numRows,
             valueBits = 14,
             valueStride = 32))
@@ -213,22 +215,20 @@ class AdcDsp(pr.Device):
         self.add(pr.RemoteVariable(
             name = 'AccumError',
             offset = 0x2000,
-            base = pr.Int,
+            base = AdcDsp.ACCUM_BASE,
             mode = 'RO',
-#            bitSize = 32*numRows,
             numValues = numRows,
-            valueBits = ACCUM_BITS,
+            valueBits = AdcDsp.ACCUM_BASE.bitSize,
             valueStride = 32))
 
 
         self.add(pr.RemoteVariable(
             name = 'SumAccum',
             offset = 0x3000,
-            base = pr.Int,
+            base = AdcDsp.ACCUM_BASE,
             mode = 'RW',
-#            bitSize = 32*numRows,
             numValues = numRows,
-            valueBits = ACCUM_BITS,
+            valueBits = AdcDsp.ACCUM_BASE.bitSize,
             valueStride = 32))
         
 
@@ -236,9 +236,9 @@ class AdcDsp(pr.Device):
             name = 'PidResults',
             offset = 0x4000,
             mode = 'RW',
-#            bitSize = 32*numRows,
+            base = AdcDsp.RESULT_BASE,
             numValues = numRows,
-            valueBits = 40, #RESULT_BITS,
+            valueBits = AdcDsp.RESULT_BASE.bitSize,
             valueStride = 64))
         
         
@@ -246,9 +246,9 @@ class AdcDsp(pr.Device):
             name = 'FilterResults',
             offset = 0x5000,
             mode = 'RO',
-#            bitSize = 32*numRows,
+            base = AdcDsp.RESULT_BASE,
             numValues = numRows,
-            valueBits = 40, #16,
+            valueBits = AdcDsp.RESULT_BASE.bitSize,
             valueStride = 64))
 
         self.add(pr.RemoteVariable(

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -78,24 +78,7 @@ class AdcDsp(pr.Device):
 
         COEF_BASE = pr.Fixed(24, 23)
         ACCUM_BASE = pr.Fixed(32, 0)
-        RESULT_BASE = pr.Fixed(56, 23)
-
-        numRows = 4
-
-        self.amp = frontEnd.Channel[column].SQ1FbAmp
-
-        self.add(pr.RemoteVariable(
-            name = 'PidEnable',
-            offset = 0x00,
-            base = pr.Bool,
-            mode = 'RW',
-            bitSize = 1,
-            bitOffset = 0))
-
-        self.add(pr.RemoteVariable(
-            name = 'AccumShift',
-            offset = 0x00,
-            base = pr.UInt,
+        RESULT_BASE = pr.Fixed(56, 23
             mode = 'RW',
             bitSize = 4,
             bitOffset = 16))
@@ -146,6 +129,14 @@ class AdcDsp(pr.Device):
             units = u'\u03bcA',            
             linkedSet = _set,
             linkedGet = _get))
+
+        self.add(pr.RemoteVariable(
+            name = 'PidDebugEnable',
+            offset = 0x50,
+            mode = 'RW',
+            base = pr.Bool,
+            bitSize = 1,
+            bitOffset = 0))
 
         self.add(pr.RemoteVariable(
             name = 'FluxJumps_DBG',

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -78,10 +78,21 @@ class AdcDsp(pr.Device):
 
         COEF_BASE = pr.Fixed(24, 23)
         ACCUM_BASE = pr.Fixed(32, 0)
-        RESULT_BASE = pr.Fixed(56, 23
+        RESULT_BASE = pr.Fixed(56, 23)
+
+        numRows = 4
+
+        self.amp = frontEnd.Channel[column].SQ1FbAmp
+
+        self.add(pr.RemoteVariable(
+            name = 'PidEnable',
+            offset = 0x00,
+            base = pr.Bool,
             mode = 'RW',
-            bitSize = 4,
-            bitOffset = 16))
+            bitSize = 1,
+            bitOffset = 0))
+
+
 
         self.add(pr.RemoteVariable(
             name = 'P_Coef',

--- a/firmware/python/warm_tdm/_AdcDsp.py
+++ b/firmware/python/warm_tdm/_AdcDsp.py
@@ -127,6 +127,7 @@ class AdcDsp(pr.Device):
 
         self.add(pr.RemoteVariable(
             name = 'FluxQuantumRaw',
+            groups = ['NoConfig'],            
             offset = 0x40,
             base = pr.Int,
             bitSize = 14,
@@ -269,6 +270,7 @@ class AdcDsp(pr.Device):
 
         self.add(RowPidStatusArray(
             name = 'RowPidStatus',
+            groups = ['NoConfig'],            
             dsp = self,
             rows = rows))
 

--- a/firmware/python/warm_tdm/_Amplifiers.py
+++ b/firmware/python/warm_tdm/_Amplifiers.py
@@ -18,20 +18,25 @@ class SaAmplifier(pr.Device):
             disp = '{:0.3f}',
             mode = 'RO',
             dependencies = sa_vars,
-            linkedGet = lambda read: 1.0e6 * self.ampVin(1/2**13, 0.0)))
+            linkedGet = lambda read: 1.0e6 * (self.ampVin(2/2**13, 0.0)-self.ampVin(1/2**13, 0.0))))
 
         self.add(pr.LinkVariable(
             name = 'AmpSaGain',
             disp = '{:0.3f}',
             mode = 'RO',
             dependencies = sa_vars,
-            linkedGet = lambda read: 1 / self.ampVin(1.0, 0.0)))
+            linkedGet = lambda read: (1-0.9) / (self.ampVin(1.0, 0.0)-self.ampVin(0.9, 0.0))))
 
 
 class ColumnBoardC00SaAmp(SaAmplifier):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        self.add(pr.LocalVariable(
+            name = 'SA_BIAS_SHUNT_R',
+            value = 15.0e3,
+            units = u'\u03a9'))
 
         self.add(pr.LocalVariable(
             name = 'SA_OFFSET_R',
@@ -50,13 +55,14 @@ class ColumnBoardC00SaAmp(SaAmplifier):
         
         self.add(pr.LocalVariable(
             name = 'SA_AMP_GAIN_2',
-            value = 11,))
+            value = 11))
         
         self.add(pr.LocalVariable(
             name = 'SA_AMP_GAIN_3',
-            value = 1.5,))
+            value = 1.0))
         
         sa_vars = [
+            self.SA_BIAS_SHUNT_R,
             self.SA_OFFSET_R,
             self.SA_AMP_FB_R,
             self.SA_AMP_GAIN_R,
@@ -65,9 +71,13 @@ class ColumnBoardC00SaAmp(SaAmplifier):
 
         self.addGainVars(sa_vars)
 
+    def saBiasCurrent(self, saBiasDacVoltageP, saBiasDacVoltageN=0.0):
+        return saBiasDacVoltageP / self.SA_BIAS_SHUNT_R.get()
 
+    def saBiasDacVoltage(self, saBiasCurrent):
+        return saBiasCurrent * self.SA_BIAS_SHUNT_R.get()
         
-    def ampVin(self, vout, voffset):
+    def ampVin(self, vout, voffsetP, voffsetN=0):
         """Calculate SA_OUT an amplifier input given amp output and voffset"""
 
         G_OFF = 1.0/self.SA_OFFSET_R.value()
@@ -76,7 +86,7 @@ class ColumnBoardC00SaAmp(SaAmplifier):
 
         V_OUT_1 = vout/(self.SA_AMP_GAIN_2.value()*self.SA_AMP_GAIN_3.value())
 
-        SA_OUT = ((G_OFF * voffset) + (G_FB * V_OUT_1)) / (G_OFF + G_FB + G_GAIN)
+        SA_OUT = ((G_OFF * voffsetP) + (G_FB * V_OUT_1)) / (G_OFF + G_FB + G_GAIN)
 
         return SA_OUT
 
@@ -86,24 +96,110 @@ class FEAmplifier3(SaAmplifier):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # Make these into variables
+        self.add(pr.LocalVariable(
+            name = 'R_CABLE',
+            description = 'Cable resistance on SA Bias',
+            value = 100.0,
+            units = u'\u03a9'))
+        
+        self.add(pr.LocalVariable(
+            name = 'BIAS_SHUNT_R_P',
+            description = 'Shunt resistance on high side of SA Bias',
+            value = 10e3 + 4.990e3,
+            units = u'\u03a9'))
+
+        self.add(pr.LocalVariable(
+            name = 'BIAS_SHUNT_R_N',
+            description = 'Shunt resistance on low side of SA bias',
+            value = 100.0,
+            units = u'\u03a9'))            
+
 
         # Stage 1 Instrumentation Amplifier
         # RF1 = R34/R33
         # RG1 = R6
-        self.RF1 = 100.0
-        self.RG1 = 18.20
+        self.add(pr.LocalVariable(
+            name = 'RF1',
+            description = 'R33 and R34',
+            value = 100.0,
+            units = u'\u03a9'))
 
+        self.add(pr.LocalVariable(
+            name = 'RG1',
+            description = 'R6',
+            value = 18.20,
+            units = u'\u03a9'))
 
-        self.GAIN_1 = 1 + (( 2 * self.RF1) / self.RG1 )
+        #self.RF1 = 100.0
+        #self.RG1 = 18.20
+
+        self.add(pr.LinkVariable(
+            name = 'GAIN_1',
+            description = 'First stage gain',
+            mode = 'RO',
+            dependencies = [self.RF1, self.RG1],
+            linkedGet = lambda read: 1 + (( 2 * self.RF1.get(read=read)) / self.RG1.get(read=read))))
+
+        self.add(pr.LocalVariable(
+            name = 'BIAS_DAC_N',
+            description = 'Voltage developed at SA_BIAS_IN_RET_SQ1B',
+            value = 50.0e-3,
+            units = 'V'))
+
 
         # Stage 2 Summing Differential Input Amplifier
-        self.RF2 = 100.0
-        self.RG2 = 33.2
-        self.ROFF = 33.2 # Offset gain
+        self.add(pr.LocalVariable(
+            name = 'RF2',
+            description = 'R35',
+            value = 100.0,
+            units = u'\u03a9'))
 
-        self.GAIN_COLUMN = 3.67
+        self.add(pr.LocalVariable(
+            name = 'RG2',
+            description = 'R15 and R17',
+            value = 33.2,
+            units = u'\u03a9'))
+
+        self.add(pr.LocalVariable(
+            name = 'R_OFFSET',
+            description = 'R16',
+            value = 402.0,
+            units = u'\u03a9'))
         
+        #self.RF2 = 100.0
+        #self.RG2 = 33.2
+        #self.ROFF = 33.2 # Offset gain
+
+        self.add(pr.LocalVariable(
+            name = 'GAIN_COLUMN',
+            description = 'Gain of final amplification state on Column board',
+            value = 3.67))
+
+        sa_vars = [
+            self.R_CABLE,
+            self.BIAS_SHUNT_R_P,
+            self.BIAS_SHUNT_R_N,
+            self.RF1,
+            self.RG1,
+            self.GAIN_1,
+            self.BIAS_DAC_N,
+            self.RF2,
+            self.RG2,
+            self.R_OFFSET,
+            self.GAIN_COLUMN]
+
+        self.addGainVars([])        
+
+        
+    def saBiasCurrent(self, saBiasDacVoltageP, saBiasDacVoltageN=0.0):
+        vdiff = saBiasDacVoltageP - (saBiasDacVoltageN + self.BIAS_DAC_N.get())
+        return vdiff / (self.R_CABLE.get() + self.BIAS_SHUNT_R_P.get() + self.BIAS_SHUNT_R_N.get())
+
+    def saBiasDacVoltage(self, saBiasCurrent):
+        resistance = self.R_CABLE.get() + self.BIAS_SHUNT_R_P.get() + self.BIAS_SHUNT_R_N.get()
+        voltage = saBiasCurrent * resistance
+        # apply neg offset
+        voltage = voltage + self.BIAS_DAC_N.get()
 
     def ampVout(self, vin, voffset):
         # Make it more readable
@@ -132,22 +228,29 @@ class FEAmplifier3(SaAmplifier):
         return vout
                            
 
-    def ampVin(self, vadc, voffset):
+    def ampVin(self, vadc, voffsetP, voffsetN=0.0):
+        print(f'ampVin({vadc=}, {voffsetP=})')
+        RF2 = self.RF2.value()
+        RG2 = self.RG2.value()
+        ROFF = self.R_OFFSET.value()
 
-        RF2 = self.RF2
-        RG2 = self.RG2
-        ROFF = self.ROFF
-
-        vout2 = vadc / self.GAIN_COLUMN
+        vout2 = vadc / self.GAIN_COLUMN.value()
+        print(f'{vout2=}')
         
 
         # Ugly equation from wolfram alpha
-        v1p = (2 * RG2 * (RF2 + RG2) * (RF2 * voffset + vout2 * ROFF)) / (RF2 * (RF2 * (RG2 - (2 * ROFF)) - (2 * RG2 * ROFF)))
-        v1p = -1.0 * v1n
+        v1p = (2 * RG2 * (RF2 + RG2) * (RF2 * voffsetP + vout2 * ROFF)) / (RF2 * (RF2 * (RG2 - (2 * ROFF)) - (2 * RG2 * ROFF)))
+        v1p = -1.0 * v1p
+        print(f'{v1p=}')
 
-        v1 = v1p - v1n
+        #v1 = v1p - v1n
+        vnn = self.BIAS_DAC_N.value()
+        print(f'{vnn=}')
 
-        vin = v1 / self.GAIN_1
+        vin = (v1p + (vnn * self.GAIN_1.value())) / self.GAIN_1.value()
+        print(f'{vin=}')
+
+        #vin = vin - self.BIAS_DAC_N.get() # Not sure this is right
 
         return vin
         

--- a/firmware/python/warm_tdm/_Amplifiers.py
+++ b/firmware/python/warm_tdm/_Amplifiers.py
@@ -72,10 +72,10 @@ class ColumnBoardC00SaAmp(SaAmplifier):
         self.addGainVars(sa_vars)
 
     def saBiasCurrent(self, saBiasDacVoltageP, saBiasDacVoltageN=0.0):
-        return saBiasDacVoltageP / self.SA_BIAS_SHUNT_R.get()
+        return saBiasDacVoltageP / self.SA_BIAS_SHUNT_R.value()
 
     def saBiasDacVoltage(self, saBiasCurrent):
-        return saBiasCurrent * self.SA_BIAS_SHUNT_R.get()
+        return saBiasCurrent * self.SA_BIAS_SHUNT_R.value()
         
     def ampVin(self, vout, voffsetP, voffsetN=0):
         """Calculate SA_OUT an amplifier input given amp output and voffset"""
@@ -188,18 +188,18 @@ class FEAmplifier3(SaAmplifier):
             self.R_OFFSET,
             self.GAIN_COLUMN]
 
-        self.addGainVars([])        
+        self.addGainVars(sa_vars)        
 
         
     def saBiasCurrent(self, saBiasDacVoltageP, saBiasDacVoltageN=0.0):
-        vdiff = saBiasDacVoltageP - (saBiasDacVoltageN + self.BIAS_DAC_N.get())
-        return vdiff / (self.R_CABLE.get() + self.BIAS_SHUNT_R_P.get() + self.BIAS_SHUNT_R_N.get())
+        vdiff = saBiasDacVoltageP - (saBiasDacVoltageN + self.BIAS_DAC_N.value())
+        return vdiff / (self.R_CABLE.value() + self.BIAS_SHUNT_R_P.value() + self.BIAS_SHUNT_R_N.value())
 
     def saBiasDacVoltage(self, saBiasCurrent):
-        resistance = self.R_CABLE.get() + self.BIAS_SHUNT_R_P.get() + self.BIAS_SHUNT_R_N.get()
+        resistance = self.R_CABLE.value() + self.BIAS_SHUNT_R_P.value() + self.BIAS_SHUNT_R_N.value()
         voltage = saBiasCurrent * resistance
         # apply neg offset
-        voltage = voltage + self.BIAS_DAC_N.get()
+        voltage = voltage + self.BIAS_DAC_N.value()
         return voltage
 
     def ampVout(self, vin, voffset):
@@ -251,7 +251,7 @@ class FEAmplifier3(SaAmplifier):
         vin = (v1p + (vnn * self.GAIN_1.value())) / self.GAIN_1.value()
         print(f'{vin=}')
 
-        #vin = vin - self.BIAS_DAC_N.get() # Not sure this is right
+        #vin = vin - self.BIAS_DAC_N.value() # Not sure this is right
 
         return vin
         

--- a/firmware/python/warm_tdm/_Amplifiers.py
+++ b/firmware/python/warm_tdm/_Amplifiers.py
@@ -230,26 +230,21 @@ class FEAmplifier3(SaAmplifier):
                            
 
     def ampVin(self, vadc, voffsetP, voffsetN=0.0):
-        print(f'ampVin({vadc=}, {voffsetP=})')
+        #print(f'ampVin({vadc=}, {voffsetP=})')
         RF2 = self.RF2.value()
         RG2 = self.RG2.value()
         ROFF = self.R_OFFSET.value()
 
         vout2 = vadc / self.GAIN_COLUMN.value()
-        print(f'{vout2=}')
-        
 
         # Ugly equation from wolfram alpha
         v1p = (2 * RG2 * (RF2 + RG2) * (RF2 * voffsetP + vout2 * ROFF)) / (RF2 * (RF2 * (RG2 - (2 * ROFF)) - (2 * RG2 * ROFF)))
         v1p = -1.0 * v1p
-        print(f'{v1p=}')
 
         #v1 = v1p - v1n
         vnn = self.BIAS_DAC_N.value()
-        print(f'{vnn=}')
 
         vin = (v1p + (vnn * self.GAIN_1.value())) / self.GAIN_1.value()
-        print(f'{vin=}')
 
         #vin = vin - self.BIAS_DAC_N.value() # Not sure this is right
 

--- a/firmware/python/warm_tdm/_Amplifiers.py
+++ b/firmware/python/warm_tdm/_Amplifiers.py
@@ -200,6 +200,7 @@ class FEAmplifier3(SaAmplifier):
         voltage = saBiasCurrent * resistance
         # apply neg offset
         voltage = voltage + self.BIAS_DAC_N.get()
+        return voltage
 
     def ampVout(self, vin, voffset):
         # Make it more readable

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -20,10 +20,8 @@ class ArrayDevice(pr.Device):
         elif isinstance(arrayArgs, dict):
             arrayArgs = [arrayArgs.copy() for x in range(number)]
 
-        print(f'{arrayArgs=}')
         for i in range(number):
             args = arrayArgs[i]
-            print(f'Adding device, args={args}')
             if 'name' in args:
                 name = args.pop('name')
                 name = f'{name}[{i}]'

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -78,7 +78,9 @@ class ColumnModule(pr.Device):
             offset = 0xC0701000))
 
         self.add(warm_tdm.TesBias(
-            dac = self.TesBiasDac))
+            offset = 0xC0702000,
+            dac = self.TesBiasDac,
+            frontEnd = self.AnalogFrontEnd))
 
         self.add(warm_tdm.FastDacDriver(
             name = 'SAFb',

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -60,6 +60,7 @@ class ColumnModule(pr.Device):
         self.add(warm_tdm.DataPath(
             offset = 0xC0300000,
             expand = True,
+            rows = rows,
             frontEnd=self.AnalogFrontEnd))
 
         self.add(warm_tdm.Ad5679R(

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -65,6 +65,7 @@ class ColumnModule(pr.Device):
 
         self.add(warm_tdm.Ad5679R(
             name = 'SaBiasDac',
+            groups = ['NoConfig'],
             hidden = True,
             offset = 0xC0700000))
 
@@ -109,7 +110,7 @@ class ColumnModule(pr.Device):
 
 
         self.add(surf.devices.analog_devices.Ad9681Config(
-            enabled = True,
+            enabled = False,
             offset = 0xC0200000))
 
         #########################################
@@ -203,12 +204,14 @@ class ColumnModule(pr.Device):
 
         @self.command()
         def InitDacAdc():
+            enable = self.Ad9681Config.enable.get()
             self.Ad9681Config.enable.set(True)
             self.Ad9681Config.ReadDevice()
             self.Ad9681Config.InternalPdwnMode.setDisp('Full Power Down')
             self.Ad9681Config.InternalPdwnMode.setDisp('Chip Run')
             self.Ad9681Config.InternalPdwnMode.setDisp('Digital Reset')
             self.Ad9681Config.InternalPdwnMode.setDisp('Chip Run')
+            self.Ad9681Config.enable.set(enable)
 
             self.DataPath.Ad9681Readout.Relock()
             self.DataPath.Ad9681Readout.LostLockCountReset()

--- a/firmware/python/warm_tdm/_ColumnModule.py
+++ b/firmware/python/warm_tdm/_ColumnModule.py
@@ -74,7 +74,7 @@ class ColumnModule(pr.Device):
 
         self.add(warm_tdm.Ad5679R(
             name = 'TesBiasDac',
-            hidden = True,
+            hidden = False,
             offset = 0xC0701000))
 
         self.add(warm_tdm.TesBias(

--- a/firmware/python/warm_tdm/_ComCore.py
+++ b/firmware/python/warm_tdm/_ComCore.py
@@ -23,6 +23,7 @@ class PgpCore(pr.Device):
             name = 'Gtxe2Channel[0]',
             enabled = False,
             hidden = True,
+            groups = ['NoConfig'],            
             offset = 0x0001000))
 
 #         self.add(surf.protocols.pgp.Pgp2bAxi(
@@ -46,23 +47,27 @@ class EthCore(pr.Device):
         self.add(surf.protocols.rssi.RssiCore(
             enabled = False,
             name = "SRP_RSSI",
+            groups = ['NoConfig'],
             offset = 0x11000,
             expand = False))
 
         self.add(surf.protocols.rssi.RssiCore(
             enabled = False,
             name = "Data_RSSI",
+            groups = ['NoConfig'],            
             offset = 0x12000,
             expand = False))
         
         self.add(surf.ethernet.udp.UdpEngine(
             enabled = False,
             offset = 0x10000,
+            groups = ['NoConfig'],            
             numSrv = 2))
 
         self.add(surf.ethernet.gige.GigEthGtx7(
             enabled = False,
             gtxe2_read_only = True,
+            groups = ['NoConfig'],            
             offset = 0x00000))
 
 

--- a/firmware/python/warm_tdm/_DataPath.py
+++ b/firmware/python/warm_tdm/_DataPath.py
@@ -9,13 +9,14 @@ import warm_tdm
 
 
 class DataPath(pr.Device):
-    def __init__(self, frontEnd, **kwargs):
+    def __init__(self, frontEnd, rows, **kwargs):
         super().__init__(**kwargs)
 
         for i in range(8):
             self.add(warm_tdm.AdcDsp(
                 name = f'AdcDsp[{i}]',
                 frontEnd = frontEnd,
+                rows = rows,
                 column = i,
                 offset = (i+1) << 16))
 

--- a/firmware/python/warm_tdm/_DataPath.py
+++ b/firmware/python/warm_tdm/_DataPath.py
@@ -9,12 +9,13 @@ import warm_tdm
 
 
 class DataPath(pr.Device):
-    def __init__(self,  **kwargs):
+    def __init__(self, frontEnd, **kwargs):
         super().__init__(**kwargs)
 
         for i in range(8):
             self.add(warm_tdm.AdcDsp(
                 name = f'AdcDsp[{i}]',
+                frontEnd = frontEnd,
                 column = i,
                 offset = (i+1) << 16))
 

--- a/firmware/python/warm_tdm/_FastDacDriver.py
+++ b/firmware/python/warm_tdm/_FastDacDriver.py
@@ -81,13 +81,13 @@ class FastDacMem(pr.Device):
         return currents
 
     def setCurrent(self, value, index, write):
-        print(f'{self.path}.setCurrent({value=}, {index=}, {write=})')
+        #print(f'{self.path}.setCurrent({value=}, {index=}, {write=})')
         if index == -1:
             dacs = [self.amps[i].outCurrentToDac(current) for i, current in enumerate(value)]
         else:
             dacs = self.amps[index].outCurrentToDac(value)
 
-        print(f'Raw.set({index=}, {write=}, value={dacs})')
+        #print(f'Raw.set({index=}, {write=}, value={dacs})')
         self.Raw.set(index=index, write=write, value=dacs)
 
     def getVoltage(self, index, read):
@@ -118,7 +118,7 @@ class FastDacDriver(pr.Device):
         self.frontEnd = frontEnd
         self.amps = [self.frontEnd.Channel[x].find(name=f'{self.name}Amp')[0] for x in range(8)]
 
-        print(self.amps)
+        #print(self.amps)
         
         # Create devices that hold amplifier configuration
 #         self.add(pr.ArrayDevice(

--- a/firmware/python/warm_tdm/_FrontEnds.py
+++ b/firmware/python/warm_tdm/_FrontEnds.py
@@ -1,0 +1,102 @@
+import pyrogue as pr
+import warm_tdm
+
+class FrontEndDevice(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(pr.LocalVariable(
+            name = 'Type',
+            mode = 'RO',
+            value = self.__class__.__name__))
+    
+
+class ColumnBoardC00StandardChannel(FrontEndDevice):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(warm_tdm.ColumnBoardC00SaAmp(
+            name = 'SAAmp'))
+
+        self.add(warm_tdm.FastDacAmplifierSE(
+            name = 'SAFbAmp',
+            defaults = {
+                'Invert': True,
+                'ShuntR': 7.15e3,
+                'FbR': 4.7e3}))
+
+        self.add(warm_tdm.FastDacAmplifierSE(
+            name = 'SQ1BiasAmp',
+            defaults = {
+                'Invert': True,
+                'ShuntR': 10.0e3,
+                'FbR': 4.7e3}))
+
+        self.add(warm_tdm.FastDacAmplifierSE(
+            name = 'SQ1FbAmp',
+            defaults = {
+                'Invert': True,
+                'ShuntR': 11.3e3,
+                'FbR': 4.7e3}))
+
+        
+class ColumnBoardC00FebBypassChannel(FrontEndDevice):
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(warm_tdm.FEAmplifier3(
+            name = 'SAAmp'))
+
+        self.add(warm_tdm.FastDacAmplifierSE(
+            name = 'SAFbAmp',
+            defaults = {
+                'Invert': True,
+                'InputR': 100.0,
+                'FbR': 502.0,        
+                'ShuntR': 7129.7        
+            }
+        ))
+
+        self.add(warm_tdm.FastDacAmplifierSE(
+            name = 'SQ1BiasAmp',
+            defaults = {
+                'Invert': True,
+                'InputR': 100.0,
+                'FbR': 502.0,                
+                'ShuntR': 2149.7
+            }
+        ))
+
+        self.add(warm_tdm.FastDacAmplifierSE(
+            name = 'SQ1FbAmp',
+            defaults = {
+                'Invert': True,
+                'InputR': 100.0,
+                'FbR': 502.0,
+                'ShuntR': 10149.7
+            }
+        ))
+
+class ColumnBoardC00StandardFrontEnd(FrontEndDevice):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        for i in range(8):
+            self.add(warm_tdm.ColumnBoardC00StandardChannel(
+                name = f'Channel[{i}]'))
+
+
+class ColumnBoardC00FebBypassCh0(FrontEndDevice):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(warm_tdm.ColumnBoardC00FebBypassChannel(
+            name = 'Channel[0]'))
+    
+        for i in range(1, 8):
+            self.add(warm_tdm.ColumnBoardC00StandardChannel(
+                name = f'Channel[{i}]'))

--- a/firmware/python/warm_tdm/_FrontEnds.py
+++ b/firmware/python/warm_tdm/_FrontEnds.py
@@ -40,6 +40,9 @@ class ColumnBoardC00StandardChannel(FrontEndDevice):
                 'ShuntR': 11.3e3,
                 'FbR': 4.7e3}))
 
+        self.add(warm_tdm.TesBiasAmpC00(
+            name = 'TesBiasAmp'))
+
         
 class ColumnBoardC00FebBypassChannel(FrontEndDevice):
     
@@ -78,6 +81,9 @@ class ColumnBoardC00FebBypassChannel(FrontEndDevice):
                 'ShuntR': 10149.7
             }
         ))
+
+        self.add(warm_tdm.TesBiasAmpC00(
+            name = 'TesBiasAmp'))
 
 class ColumnBoardC00StandardFrontEnd(FrontEndDevice):
 

--- a/firmware/python/warm_tdm/_HardwareGroup.py
+++ b/firmware/python/warm_tdm/_HardwareGroup.py
@@ -36,8 +36,8 @@ class HardwareGroup(pyrogue.Device):
 
         # Open rUDP connections to the Manager board
         if simulation is False and emulate is False:
-            srpUdp = pyrogue.protocols.UdpRssiPack(host=host, port=SRP_PORT, packVer=2, name='SrpRssi')
-            dataUdp = pyrogue.protocols.UdpRssiPack(host=host, port=DATA_PORT, packVer=2, name='DataRssi', enSsi=False)
+            srpUdp = pyrogue.protocols.UdpRssiPack(host=host, port=SRP_PORT, packVer=2, name='SrpRssi', groups=['NoConfig'])
+            dataUdp = pyrogue.protocols.UdpRssiPack(host=host, port=DATA_PORT, packVer=2, name='DataRssi', enSsi=False, groups=['NoConfig'])
             self.add(srpUdp)
             self.add(dataUdp)
             self.addInterface(srpUdp, dataUdp)
@@ -168,6 +168,7 @@ class HardwareGroup(pyrogue.Device):
                 name = 'ReadoutList',
                 typeStr = 'int',
                 value = [0] ,
+                groups = ['NoConfig'],
                 dependencies = [
                     self.ColumnBoard[0].WarmTdmCore.Timing.TimingTx.NumRows,
                     self.ColumnBoard[0].WarmTdmCore.Timing.TimingTx.RowIndexOrder],

--- a/firmware/python/warm_tdm/_HardwareGroup.py
+++ b/firmware/python/warm_tdm/_HardwareGroup.py
@@ -19,6 +19,7 @@ class HardwareGroup(pyrogue.Device):
     def __init__(
             self,
             groupId,
+            frontEndClass,
             dataWriter,
             simulation=False,
             emulate=False,
@@ -78,12 +79,14 @@ class HardwareGroup(pyrogue.Device):
             # Instantiate the board Device tree and link it to the SRP
             self.add(warm_tdm.ColumnModule(
                 name=f'ColumnBoard[{index}]',
+                frontEndClass=frontEndClass,
                 memBase=srp,
                 expand=True,
                 rows=rows))
             
-            pidDebug = [warm_tdm.PidDebugger(name=f'PidDebug[{i}]', hidden=False, numRows=rows, col=i, fastDacDriver=self.ColumnBoard[index].SQ1Fb) for i in range(8)]
-            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, amplifiers=self.ColumnBoard[index].amplifiers)
+            pidDebug = [warm_tdm.PidDebugger(name=f'PidDebug[{i}]', hidden=False, numRows=rows, col=i, frontEnd=self.ColumnBoard[index].AnalogFrontEnd) for i in range(8)]
+            saAmps = [self.ColumnBoard[index].AnalogFrontEnd.Channel[x].SAAmp for x in range(8)]
+            waveGui = warm_tdm.WaveformCaptureReceiver(hidden=False, amplifiers=saAmps)
 
             # Link the data stream to the DataWriter
             if emulate is False:

--- a/firmware/python/warm_tdm/_HardwareGroup.py
+++ b/firmware/python/warm_tdm/_HardwareGroup.py
@@ -145,12 +145,12 @@ class HardwareGroup(pyrogue.Device):
                 enabled=True))
 
         def rl_get(read):
-            print(f'rl_get({read=})')
+            #print(f'rl_get({read=})')
             length = self.ColumnBoard[0].WarmTdmCore.Timing.TimingTx.NumRows.get(read=read)
-            print(f'{length=}')
+            #print(f'{length=}')
             order = self.ColumnBoard[0].WarmTdmCore.Timing.TimingTx.RowIndexOrder.get(read=read)
-            print(f'{order=}')
-            print(f'ret - {order[0:length]}')
+            #print(f'{order=}')
+            #print(f'ret - {order[0:length]}')
             return order[0:length]
 
         def rl_set(value, write):

--- a/firmware/python/warm_tdm/_PidDebugger.py
+++ b/firmware/python/warm_tdm/_PidDebugger.py
@@ -1,6 +1,7 @@
 import pyrogue as pr
 import pyrogue.interfaces.simulation
 import numpy as np
+import warm_tdm
 
 class PidRowDebugger(pr.Device):
     def __init__(self, debugDev, row, **kwargs):
@@ -91,31 +92,31 @@ class PidDebugger(pr.DataReceiver):
             name = 'AccumError',
             mode = 'RO',
             offset = 2 * 8,
-            base = pr.Fixed(22, 0),
-            bitSize = 22))
+            base = warm_tdm.AdcDsp.ACCUM_BASE,
+            bitSize = warm_tdm.AdcDsp.ACCUM_BASE.bitSize))
 
         self.add(pr.RemoteVariable(
             name = 'SumAccum',
             mode = 'RO',
             offset = 4 * 8,
-            base = pr.Fixed(22, 0),
-            bitSize = 22))
+            base = warm_tdm.AdcDsp.ACCUM_BASE,
+            bitSize = warm_tdm.AdcDsp.ACCUM_BASE.bitSize))
 
 
         self.add(pr.RemoteVariable(
             name = 'Diff',
             mode = 'RO',
             offset = 5 * 8,
-            base = pr.Fixed(22, 0),
-            bitSize = 22))
+            base = warm_tdm.AdcDsp.ACCUM_BASE,
+            bitSize = warm_tdm.AdcDsp.ACCUM_BASE.bitSize))
 
         self.add(pr.RemoteVariable(
             name = 'PidResult',
             mode = 'RO',
             offset = 6 * 8,
             disp = '{:0.03f}',
-            base = pr.Fixed(40, 17),
-            bitSize = 40))
+            base = warm_tdm.AdcDsp.RESULT_BASE,
+            bitSize = warm_tdm.AdcDsp.RESULT_BASE.bitSize))
 
         self.add(pr.RemoteVariable(
             name = 'Sq1FbPreRaw',

--- a/firmware/python/warm_tdm/_PidDebugger.py
+++ b/firmware/python/warm_tdm/_PidDebugger.py
@@ -171,7 +171,7 @@ class PidDebugger(pr.DataReceiver):
         raw = bytearray(fl)
         frame.read(raw, 0)
 
-        print(f'Got PID Debug frame for col {self.col}, row {raw[1]}, size {fl}')
+        #print(f'Got PID Debug frame for col {self.col}, row {raw[1]}, size {fl}')
         if fl != 72:
             return
 

--- a/firmware/python/warm_tdm/_PidDebugger.py
+++ b/firmware/python/warm_tdm/_PidDebugger.py
@@ -158,6 +158,7 @@ class PidDebugger(pr.DataReceiver):
 
         self.add(pr.ArrayDevice(
             name = 'RowPids',
+            groups = ['NoConfig'],
             arrayClass = PidRowDebugger,
             number = numRows,
             arrayArgs = [{

--- a/firmware/python/warm_tdm/_PidDebugger.py
+++ b/firmware/python/warm_tdm/_PidDebugger.py
@@ -84,9 +84,19 @@ class PidDebugger(pr.DataReceiver):
             name = 'RowIndex',
             mode = 'RO',
             offset = 0,
+            disp = '{:d}',
             base = pr.UInt,
             bitOffset = 8,
             bitSize = 8))
+
+        self.add(pr.RemoteVariable(
+            name = 'RunTime',
+            mode = 'RO',
+            offset = 0,
+            bitOffset = 16,
+            bitSize = 48,
+            disp = '{:d}',
+            base = pr.UInt))
 
         self.add(pr.RemoteVariable(
             name = 'AccumError',

--- a/firmware/python/warm_tdm/_PidDebugger.py
+++ b/firmware/python/warm_tdm/_PidDebugger.py
@@ -65,7 +65,7 @@ class PidRowDebugger(pr.Device):
 
 class PidDebugger(pr.DataReceiver):
 
-    def __init__(self, numRows, col, fastDacDriver, **kwargs):
+    def __init__(self, numRows, col, frontEnd, **kwargs):
         self.mem = pyrogue.interfaces.simulation.MemEmulate()
 
         self.col = col
@@ -130,7 +130,7 @@ class PidDebugger(pr.DataReceiver):
             disp = '{:0.03f}',
             units = u'\u03bcA',
             dependencies = [self.Sq1FbPreRaw, self.Column],
-            linkedGet = lambda: fastDacDriver.AmpLoading.Amp[self.Column.value()].dacToOutCurrent(self.Sq1FbPreRaw.value())))
+            linkedGet = lambda: frontEnd.Channel[self.Column.value()].SQ1FbAmp.dacToOutCurrent(self.Sq1FbPreRaw.value())))
 
         self.add(pr.RemoteVariable(
             name = 'Sq1FbPostRaw',
@@ -145,7 +145,7 @@ class PidDebugger(pr.DataReceiver):
             disp = '{:0.03f}',
             units = u'\u03bcA',
             dependencies = [self.Sq1FbPostRaw, self.Column],
-            linkedGet = lambda: fastDacDriver.AmpLoading.Amp[self.Column.value()].dacToOutCurrent(self.Sq1FbPostRaw.value())))
+            linkedGet = lambda: frontEnd.Channel[self.Column.value()].SQ1FbAmp.dacToOutCurrent(self.Sq1FbPostRaw.value())))
 
         self.add(pr.RemoteVariable(
             name = 'FluxJumps',

--- a/firmware/python/warm_tdm/_RowDacDriver.py
+++ b/firmware/python/warm_tdm/_RowDacDriver.py
@@ -57,12 +57,14 @@ class RowDacDriver(pr.Device):
 
         self.add(pr.RemoteVariable(
             name = 'ActivateRowIndex',
+            groups = ['NoConfig'],
             offset = 0x10,
             bitSize = 8,
             base = pr.UInt))
 
         self.add(pr.RemoteVariable(
             name = 'DeactivateRowIndex',
+            groups = ['NoConfig'],            
             offset = 0x14,
             bitSize = 8,
             base = pr.UInt))

--- a/firmware/python/warm_tdm/_RowModule.py
+++ b/firmware/python/warm_tdm/_RowModule.py
@@ -17,10 +17,12 @@ class RowModule(pr.Device):
             therm_channels = [3, 11, 4, 12]))
         
         self.add(surf.protocols.ssi.SsiPrbsRx(
+            enabled = False,
             hidden = True,
             offset = 0xC0200000))
         
         self.add(surf.protocols.ssi.SsiPrbsTx(
+            enabled = False,
             hidden = True,
             offset = 0xC0201000))
 

--- a/firmware/python/warm_tdm/_RowModule.py
+++ b/firmware/python/warm_tdm/_RowModule.py
@@ -14,6 +14,7 @@ class RowModule(pr.Device):
         self.add(warm_tdm.WarmTdmCore(
             offset = 0x00000000,
             expand = True,
+            disable_timing_tx = True,
             therm_channels = [3, 11, 4, 12]))
         
         self.add(surf.protocols.ssi.SsiPrbsRx(

--- a/firmware/python/warm_tdm/_SaBiasOffset.py
+++ b/firmware/python/warm_tdm/_SaBiasOffset.py
@@ -13,6 +13,7 @@ class SaBiasOffset(pr.Device):
 
         self.add(pr.LocalVariable(
             name = 'TriggerWaveform',
+            groups = ['NoConfig'],
             value = False))
 
 
@@ -24,6 +25,7 @@ class SaBiasOffset(pr.Device):
 
             self.add(pr.LinkVariable(
                 name = f'BiasVoltage[{i}]',
+                groups = ['NoConfig'],                
                 dependencies = [self._dac.DacVoltage[i]],
                 linkedSet = _setBias,
                 linkedGet = lambda read, ch=i: self._dac.DacVoltage[ch].get(read=read),
@@ -57,6 +59,7 @@ class SaBiasOffset(pr.Device):
         self.add(pr.LinkVariable(
             name = 'OffsetVoltageArray',
             hidden = True,
+            groups = ['NoConfig'],            
             dependencies = [x for x in self.OffsetVoltage.values()],
             linkedGet = lambda read, index: self.OffsetVoltage[index].get(read) if index != -1 else np.array([x.get(read=read) for x in self.OffsetVoltage.values()])))
 

--- a/firmware/python/warm_tdm/_SaBiasOffset.py
+++ b/firmware/python/warm_tdm/_SaBiasOffset.py
@@ -2,12 +2,13 @@ import pyrogue as pr
 import numpy as np
 
 class SaBiasOffset(pr.Device):
-    def __init__(self, dac, waveformTrigger, **kwargs):
+    def __init__(self, dac, frontEnd, waveformTrigger, **kwargs):
         super().__init__(**kwargs)
 
         self.shunt = 15.0e3
 
         self._dac = dac
+        self._amps = [frontEnd.Channel[x].SAAmp for x in range(8)]
         self._waveformTrigger = waveformTrigger
 
         self.add(pr.LocalVariable(
@@ -37,12 +38,19 @@ class SaBiasOffset(pr.Device):
                 variable = self._dac.DacVoltage[i+8],
                 units = 'V'))
 
+
         for i in range(8):
+            def biasCurrentGet(read, ch=i):
+                return self._amps[ch].saBiasCurrent(self.BiasVoltage[ch].get(read=read)) * 1.0e6
+
+            def biasCurrentSet(value, write, ch=i):
+                self.BiasVoltage[ch].set(self._amps[ch].saBiasDacVoltage(value/1.0e6), write=write)
+            
             self.add(pr.LinkVariable(
                 name = f'BiasCurrent[{i}]',
                 dependencies = [self.BiasVoltage[i]],
-                linkedGet = lambda read, ch=i: self.BiasVoltage[ch].get(read=read) * 1e6 / self.shunt,
-                linkedSet = lambda value, write, ch=i: self.BiasVoltage[ch].set((value/1e6) * self.shunt, write=write),
+                linkedGet = biasCurrentGet,
+                linkedSet = biasCurrentSet,
                 disp = '{:0.01f}',
                 units = u'\u03bcA'))
 

--- a/firmware/python/warm_tdm/_TesBias.py
+++ b/firmware/python/warm_tdm/_TesBias.py
@@ -1,36 +1,49 @@
 import pyrogue as pr
 
+
 class TesBias(pr.Device):
-    def __init__(self, dac, **kwargs):
+    def __init__(self, frontEnd, dac, **kwargs):
         super().__init__(**kwargs)
+        
+        self._frontEnd = frontEnd
         self._dac = dac
+
+        # Add Delatch registers
+        for i in range(8):
+            self.add(pr.RemoteVariable(
+                name = f'Delatch[{i}]',
+                offset = 0,
+                bitOffset = i,
+                bitSize = 1,
+                base = pr.Bool))
 
         for i in range(8):
             self.add(pr.LinkVariable(
                 name = f'BiasCurrent[{i}]',
                 disp = '{:1.3f}',                
                 units = '\u03bcA',
-                dependencies = [self._dac.DacVoltage[i], self._dac.DacVoltage[i+8]],
+                dependencies = [self._dac.DacVoltage[i], self._dac.DacVoltage[i+8], self.Delatch[i]],
                 linkedSet = self._setChannelFunc(i),
                 linkedGet = self._getChannelFunc(i)))
 
 
-    # TES Bias current source gain is 1 mA / V
+    # TES Bias current 
     def _setChannelFunc(self, channel):
-        def _setChannel(value, write):
-            #dacChannels = [self._dac.InpVoltage[channel], self._dac.InpVoltage[channel+8]]
-            v1 = value  / .5e3
-            if v1 > 0:
-                self._dac.setVoltages([channel, channel+8], [v1, 0])
-            else:
-                self._dac.setVoltages([channel, channel+8], [0, -1*v1])
+        def _setChannel(value, write, tesAmp=self._frontEnd.Channel[channel].TesBiasAmp):
+            # Calculate the DAC voltages to drive
+            vp, vn = tesAmp.outCurrentToDac(value, self.Delatch[channel].value())
+            # Set the DAC voltages
+            self._dac.setVoltages([channel, channel+8], [vp, vn])
+            
         return _setChannel
 
     def _getChannelFunc(self, channel):
-        def _getChannel(read):
+        def _getChannel(read, tesAmp=self._frontEnd.Channel[channel].TesBiasAmp):
             dacChannels = [self._dac.DacVoltage[channel], self._dac.DacVoltage[channel+8]]
-            dacValues = [dacChannels[0].value(), dacChannels[1].value()]
-            v1 = dacValues[0] - dacValues[1]
-            iOut = (v1*.5) * 1e3
-            return iOut
+            dacVp = dacChannels[0].value()
+            dacVn = dacChannels[1].value()
+            delatch = self.Delatch[channel].value()
+
+            iout = tesAmp.dacToOutCurrent(dacVp, dacVn, delatch)
+            return iout
         return _getChannel

--- a/firmware/python/warm_tdm/_Timing.py
+++ b/firmware/python/warm_tdm/_Timing.py
@@ -4,11 +4,12 @@ import pyrogue as pr
 import warm_tdm
 
 class Timing(pr.Device):
-    def __init__(self, **kwargs):
+    def __init__(self, disable_tx=False, **kwargs):
         super().__init__(**kwargs)
 
         self.add(warm_tdm.TimingRx(
             offset = 0x00000))
 
         self.add(warm_tdm.TimingTx(
+            enabled = not disable_tx,
             offset = 0x10000))

--- a/firmware/python/warm_tdm/_TimingTx.py
+++ b/firmware/python/warm_tdm/_TimingTx.py
@@ -78,12 +78,18 @@ class TimingTx(pr.Device):
             function = pr.Command.toggle))
 
         self.add(pr.RemoteCommand(
-            name = 'RawAdc',
+            name = 'WaveformCapture',
             offset = 0x20,
             bitOffset = 0,
             bitSize = 1,
             function = pr.Command.touchOne))
-        
+
+        self.add(pr.RemoteCommand(
+            name = 'WaveformCaptureTime',
+            offset = 0x28,
+            bitOffset = 0,
+            bitSize = 32,
+            disp = '{:d}'))        
 
         self.add(pr.RemoteVariable(
             name = 'RowPeriod',

--- a/firmware/python/warm_tdm/_TimingTx.py
+++ b/firmware/python/warm_tdm/_TimingTx.py
@@ -84,12 +84,12 @@ class TimingTx(pr.Device):
             bitSize = 1,
             function = pr.Command.touchOne))
 
-        self.add(pr.RemoteCommand(
-            name = 'WaveformCaptureTime',
-            offset = 0x28,
-            bitOffset = 0,
-            bitSize = 32,
-            disp = '{:d}'))        
+        # self.add(pr.RemoteVariable(
+        #     name = 'WaveformCaptureTime',
+        #     offset = 0x28,
+        #     bitOffset = 0,
+        #     bitSize = 32,
+        #     disp = '{:d}'))        
 
         self.add(pr.RemoteVariable(
             name = 'RowPeriod',

--- a/firmware/python/warm_tdm/_TimingTx.py
+++ b/firmware/python/warm_tdm/_TimingTx.py
@@ -61,7 +61,7 @@ class TimingTx(pr.Device):
             units = 'MHz',
             dependencies = [self.TxWordClkFreqRaw],
             linkedGet = lambda: self.TxWordClkFreqRaw.value()*1.0E-6))
-        
+
 
         self.add(pr.RemoteCommand(
             name = 'StartRun',
@@ -89,15 +89,33 @@ class TimingTx(pr.Device):
             offset = 0x28,
             bitOffset = 0,
             bitSize = 32,
-            disp = '{:d}'))        
+            disp = '{:d}'))
 
         self.add(pr.RemoteVariable(
-            name = 'RowPeriod',
+            name = 'RowPeriodCycles',
             mode = 'RW',
             offset = 0x08,
             bitOffset = 0,
             bitSize = 32,
             disp = '{:d}'))
+
+        self.add(pr.LinkVariable(
+            name = 'RowRate',
+            mode = 'RW',
+            dependencies = [self.RowPeriodCycles],
+            disp = '{:0.03f}',
+            units = 'kHz (kRows/sec)',
+            linkedGet = lambda read: 1.0e-3 / (self.RowPeriod.get(read=read) * 8.0e-9),
+            linkedSet = lambda value, write: self.RowPeriod.set(1.0 / ((value * 1.0e3) * 8.0e-9), write=write)))
+
+        self.add(pr.LinkVariable(
+            name = 'RowPeriod',
+            mode = 'RW',
+            dependencies = [self.RowRate],
+            disp = '{:0.03f}',
+            units = '\u03bcSec',
+            linkedGet = lambda read: 1.0e3 / self.RowRate.get(read=read),
+            linkedSet = lambda value, write: self.RowRate.set(1.0e-3 / value)))
 
         self.add(pr.RemoteVariable(
             name = 'NumRows',
@@ -114,7 +132,7 @@ class TimingTx(pr.Device):
             bitOffset = 0,
             bitSize = 32,
             disp = '{:d}'))
-        
+
         self.add(pr.RemoteVariable(
             name = 'SampleEndTime',
             mode = 'RW',
@@ -122,7 +140,7 @@ class TimingTx(pr.Device):
             bitOffset = 0,
             bitSize = 32,
             disp = '{:d}'))
-        
+
         self.add(pr.RemoteVariable(
             name = 'LoadDacsTime',
             mode = 'RW',
@@ -130,7 +148,7 @@ class TimingTx(pr.Device):
             bitOffset = 0,
             bitSize = 32,
             disp = '{:d}'))
-        
+
         self.add(pr.RemoteVariable(
             name = 'Running',
             mode = 'RO',
@@ -199,7 +217,7 @@ class TimingTx(pr.Device):
             enum = {
                 0: 'RJ-45 RX',
                 1: 'FPGA TX'}))
-        
+
         self.add(pr.RemoteVariable(
             name = 'XbarTxDataSrc',
             mode = 'RW',
@@ -262,8 +280,8 @@ class TimingTx(pr.Device):
             enum = {
                 0: 'RJ-45 RX',
                 1: 'FPGA TX'}))
-        
-        
+
+
         self.add(pr.RemoteVariable(
             name = 'RowIndexOrder',
             offset = 0x1000,

--- a/firmware/python/warm_tdm/_TimingTx.py
+++ b/firmware/python/warm_tdm/_TimingTx.py
@@ -84,12 +84,12 @@ class TimingTx(pr.Device):
             bitSize = 1,
             function = pr.Command.touchOne))
 
-        # self.add(pr.RemoteVariable(
-        #     name = 'WaveformCaptureTime',
-        #     offset = 0x28,
-        #     bitOffset = 0,
-        #     bitSize = 32,
-        #     disp = '{:d}'))        
+        self.add(pr.RemoteVariable(
+            name = 'WaveformCaptureTime',
+            offset = 0x28,
+            bitOffset = 0,
+            bitSize = 32,
+            disp = '{:d}'))        
 
         self.add(pr.RemoteVariable(
             name = 'RowPeriod',

--- a/firmware/python/warm_tdm/_TimingTx.py
+++ b/firmware/python/warm_tdm/_TimingTx.py
@@ -105,8 +105,8 @@ class TimingTx(pr.Device):
             dependencies = [self.RowPeriodCycles],
             disp = '{:0.03f}',
             units = 'kHz (kRows/sec)',
-            linkedGet = lambda read: 1.0e-3 / (self.RowPeriod.get(read=read) * 8.0e-9),
-            linkedSet = lambda value, write: self.RowPeriod.set(1.0 / ((value * 1.0e3) * 8.0e-9), write=write)))
+            linkedGet = lambda read: 1.0e-3 / (max(float(self.RowPeriodCycles.get(read=read)), 1.0e-12) * 8.0e-9),
+            linkedSet = lambda value, write: self.RowPeriodCycles.set(1.0 / ((value * 1.0e3) * 8.0e-9), write=write)))
 
         self.add(pr.LinkVariable(
             name = 'RowPeriod',

--- a/firmware/python/warm_tdm/_WarmTdmCommon.py
+++ b/firmware/python/warm_tdm/_WarmTdmCommon.py
@@ -20,35 +20,42 @@ class WarmTdmCommon(pr.Device):
         self.add(surf.xilinx.Xadc(
             enabled = False,
             offset = 0x00001000,
+            groups = ['NoConfig'],
             auxChannels = therm_channels))
 
         self.add(surf.devices.micron.AxiMicronN25Q(
             enabled = False,
+            groups = ['NoConfig'],
             offset = 0x00002000))
 
         self.add(surf.devices.nxp.Sa56004x(
             enabled = False,
+            groups = ['NoConfig'],
             offset = 0x00010000))
 
         self.add(surf.devices.linear.Ltc4151(
             name = 'Ltc4151_Digital',
             enabled = False,
+            groups = ['NoConfig'],
             senseRes = 0.02,
             offset = 0x00010400))
 
         self.add(surf.devices.linear.Ltc4151(
             name = 'Ltc4151_Analog',
             enabled = False,
-            senseRes = 0.02,            
+            groups = ['NoConfig'],
+            senseRes = 0.02,
             offset = 0x00010800))
-        
+
         self.add(surf.devices.microchip.Axi24LC64FT(
             enabled = False,
+            groups = ['NoConfig'],
             offset = 0x00080000))
 
         self.add(warm_tdm.Ad5263(
             enabled = False,
             hidden = True,
+            groups = ['NoConfig'],
             offset = 0x000C0000))
 
         self.add(warm_tdm.BoardTemp(

--- a/firmware/python/warm_tdm/_WarmTdmCore.py
+++ b/firmware/python/warm_tdm/_WarmTdmCore.py
@@ -3,7 +3,7 @@ import pyrogue as pr
 import warm_tdm
 
 class WarmTdmCore(pr.Device):
-    def __init__(self, therm_channels, **kwargs):
+    def __init__(self, therm_channels, disable_timing_tx=False, **kwargs):
         super().__init__(**kwargs)
 
         self.add(warm_tdm.WarmTdmCommon(
@@ -13,6 +13,7 @@ class WarmTdmCore(pr.Device):
 
         self.add(warm_tdm.Timing(
             offset = 0x00100000,
+            disable_tx = disable_timing_tx,
             expand = True))
 
         self.add(warm_tdm.ComCore(

--- a/firmware/python/warm_tdm/_WarmTdmRoot.py
+++ b/firmware/python/warm_tdm/_WarmTdmRoot.py
@@ -42,9 +42,11 @@ class WarmTdmRoot(pyrogue.Root):
             host,
             rowBoards,
             colBoards,
+            frontEndClass,            
             simulation=False,
             emulate=False,
             plots=False,
+
             **kwargs):
 
         # Disable polling and set a longer timeout in simulation mode
@@ -65,6 +67,7 @@ class WarmTdmRoot(pyrogue.Root):
 
         self.add(warm_tdm.HardwareGroup(
             groupId=0,
+            frontEndClass=frontEndClass,
             dataWriter=self.DataWriter,
             simulation=simulation,
             emulate=emulate,

--- a/firmware/python/warm_tdm/_WarmTdmRoot.py
+++ b/firmware/python/warm_tdm/_WarmTdmRoot.py
@@ -67,6 +67,7 @@ class WarmTdmRoot(pyrogue.Root):
 
         self.add(warm_tdm.HardwareGroup(
             groupId=0,
+            rows=32,
             frontEndClass=frontEndClass,
             dataWriter=self.DataWriter,
             simulation=simulation,

--- a/firmware/python/warm_tdm/_WaveformCapture.py
+++ b/firmware/python/warm_tdm/_WaveformCapture.py
@@ -385,7 +385,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
                      for ch in range(8)}
 
             else:
-                print(f'Setting data for channel {channel}')
+                #print(f'Setting data for channel {channel}')
                 for sample in range(len(voltages)):
                     ampVin[sample] = self.amplifiers[channel].ampVin(voltages[sample], 0.0)
 

--- a/firmware/python/warm_tdm/_WaveformCapture.py
+++ b/firmware/python/warm_tdm/_WaveformCapture.py
@@ -39,6 +39,7 @@ class WaveformCapture(pr.Device):
 
         self.add(pr.RemoteVariable(
             name = 'SelectedChannel',
+            disp = '{:d}',
             offset = 0x00,
             bitOffset = 0,
             bitSize = 3))
@@ -366,7 +367,7 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
                 self.RmsNoiseRaw.set(value=adcs.std(), index=channel)
 
             
-            adcs = adcs[5000:]
+            #adcs = adcs[5000:]
 
             voltages = self.conv(adcs)
             ampVin = np.zeros_like(voltages)

--- a/firmware/python/warm_tdm/_WaveformCapture.py
+++ b/firmware/python/warm_tdm/_WaveformCapture.py
@@ -365,6 +365,9 @@ class WaveformCaptureReceiver(pr.Device, rogue.interfaces.stream.Slave):
             else:
                 self.RmsNoiseRaw.set(value=adcs.std(), index=channel)
 
+            
+            adcs = adcs[5000:]
+
             voltages = self.conv(adcs)
             ampVin = np.zeros_like(voltages)
 

--- a/firmware/python/warm_tdm/__init__.py
+++ b/firmware/python/warm_tdm/__init__.py
@@ -9,6 +9,7 @@ from warm_tdm._Ad9106 import *
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 from warm_tdm._Amplifiers import *
+from warm_tdm._FrontEnds import *
 from warm_tdm._TimingRx import *
 from warm_tdm._TimingTx import *
 from warm_tdm._Timing import *

--- a/firmware/simulations/StackTb/tb/StackTb.vhd
+++ b/firmware/simulations/StackTb/tb/StackTb.vhd
@@ -2,7 +2,7 @@
 -- File       : RceSimTb.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2018-06-23
--- Last update: 2024-05-08
+-- Last update: 2024-06-11
 -------------------------------------------------------------------------------
 -- Description: Simulation Testbed for testing the SimpleRogueSim module
 -------------------------------------------------------------------------------
@@ -59,6 +59,7 @@ begin
          generic map (
             TPD_G                   => TPD_G,
             RING_ADDR_0_G           => (i = 0),
+            SIMULATE_PGP_G          => SIM_PGP_GT_C,
             SIM_PGP_PORT_NUM_G      => 7000 + (40 *i),  --ite(SIM_PGP_GT_C, 0, 7000),
             SIM_ETH_SRP_PORT_NUM_G  => 10000 + (i * 1000),
             SIM_ETH_DATA_PORT_NUM_G => 20000 + (i * 1000))
@@ -89,6 +90,7 @@ begin
          generic map (
             TPD_G                   => TPD_G,
             RING_ADDR_0_G           => false,
+            SIMULATE_PGP_G          => SIM_PGP_GT_C,
             SIM_PGP_PORT_NUM_G      => 70000 + (40*i),                                  --7000 + 40,
             SIM_ETH_SRP_PORT_NUM_G  => 10000 + (i * 1000),                              -- Not used
             SIM_ETH_DATA_PORT_NUM_G => 20000 + (i * 1000))                              -- Not used

--- a/firmware/targets/ColumnModule/rtl/ColumnModule.vhd
+++ b/firmware/targets/ColumnModule/rtl/ColumnModule.vhd
@@ -43,6 +43,7 @@ entity ColumnModule is
    generic (
       TPD_G                   : time             := 1 ns;
       SIMULATION_G            : boolean          := false;
+      SIMULATE_PGP_G          : boolean          := true;
       SIM_PGP_PORT_NUM_G      : integer          := 0;
       SIM_ETH_SRP_PORT_NUM_G  : integer          := 8000;
       SIM_ETH_DATA_PORT_NUM_G : integer          := 9000;
@@ -275,6 +276,7 @@ begin
       generic map (
          TPD_G                   => TPD_G,
          SIMULATION_G            => SIMULATION_G,
+         SIMULATE_PGP_G          => SIMULATE_PGP_G,
          SIM_PGP_PORT_NUM_G      => SIM_PGP_PORT_NUM_G,
          SIM_ETH_SRP_PORT_NUM_G  => SIM_ETH_SRP_PORT_NUM_G,
          SIM_ETH_DATA_PORT_NUM_G => SIM_ETH_DATA_PORT_NUM_G,
@@ -284,7 +286,7 @@ begin
          DHCP_G                  => DHCP_G,
          IP_ADDR_G               => IP_ADDR_G,
          MAC_ADDR_G              => MAC_ADDR_G,
-         XADC_AUX_CHANS_G        => (9, 1, 8, 0))         
+         XADC_AUX_CHANS_G        => (9, 1, 8, 0))
       port map (
          gtRefClk0P       => gtRefClk0P,          -- [in]
          gtRefClk0N       => gtRefClk0N,          -- [in]

--- a/firmware/targets/ColumnModule/rtl/ColumnModule.vhd
+++ b/firmware/targets/ColumnModule/rtl/ColumnModule.vhd
@@ -2,10 +2,10 @@
 -- Title      : Warm TDM Row Module
 -------------------------------------------------------------------------------
 -- Company    : SLAC National Accelerator Laboratory
--- Platform   : 
+-- Platform   :
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
--- Description: Top level of ColumnModule 
+-- Description: Top level of ColumnModule
 -------------------------------------------------------------------------------
 -- This file is part of Warm TDM. It is subject to
 -- the license terms in the LICENSE.txt file found in the top-level directory
@@ -190,7 +190,7 @@ end entity ColumnModule;
 
 architecture rtl of ColumnModule is
 
-   constant NUM_AXIL_MASTERS_C  : integer := 7;
+   constant NUM_AXIL_MASTERS_C  : integer := 8;
    constant AXIL_ADC_CONFIG_C   : integer := 0;
    constant AXIL_DATA_PATH_C    : integer := 1;
    constant AXIL_SQ1_BIAS_DAC_C : integer := 2;
@@ -198,6 +198,7 @@ architecture rtl of ColumnModule is
    constant AXIL_SA_FB_DAC_C    : integer := 4;
    constant AXIL_SA_BIAS_DAC_C  : integer := 5;
    constant AXIL_TES_BIAS_DAC_C : integer := 6;
+   constant AXIL_TES_DELATCH_C : integer := 7;
 
    constant AXIL_XBAR_CFG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXIL_MASTERS_C-1 downto 0) := (
       AXIL_ADC_CONFIG_C   => (
@@ -227,7 +228,12 @@ architecture rtl of ColumnModule is
       AXIL_TES_BIAS_DAC_C => (
          baseAddr         => APP_BASE_ADDR_C + X"00701000",
          addrBits         => 12,
+         connectivity     => X"FFFF"),
+      AXIL_TES_DELATCH_C => (
+         baseAddr         => APP_BASE_ADDR_C + X"00702000",
+         addrBits         => 8,
          connectivity     => X"FFFF"));
+
 
    signal axilClk : sl;
    signal axilRst : sl;
@@ -264,7 +270,7 @@ architecture rtl of ColumnModule is
 
    signal adc : Ad9681SerialType;
 
-
+   signal tesDelatchInt : slv(31 downto 0);
 
 begin
 
@@ -336,7 +342,7 @@ begin
          dataTxAxisMaster => dataTxAxisMaster,    -- [in]
          dataTxAxisSlave  => dataTxAxisSlave,     -- [out]
          dataRxAxisMaster => dataRxAxisMaster,    -- [out]
-         dataRxAxisSlave  => dataRxAxisSlave,     -- [in]         
+         dataRxAxisSlave  => dataRxAxisSlave,     -- [in]
          timingRxClk125   => timingRxClk125,      -- [out]
          timingRxRst125   => timingRxRst125,      -- [out]
          timingRxData     => timingRxData);       -- [out]
@@ -421,6 +427,21 @@ begin
          coreSDout      => tesDacMosi,                                -- [out]
          coreMCsb(0)    => tesDacSyncB);                              -- [out]
 
+   U_AxiLiteRegs_1 : entity surf.AxiLiteRegs
+      generic map (
+         TPD_G           => TPD_G,
+         NUM_WRITE_REG_G => 1,
+         NUM_READ_REG_G  => 1)
+      port map (
+         axiClk           => axilClk,                                  -- [in]
+         axiClkRst        => axilRst,                                  -- [in]
+         axiReadMaster    => locAxilReadMasters(AXIL_TES_DELATCH_C),   -- [in]
+         axiReadSlave     => locAxilReadSlaves(AXIL_TES_DELATCH_C),    -- [out]
+         axiWriteMaster   => locAxilWriteMasters(AXIL_TES_DELATCH_C),  -- [in]
+         axiWriteSlave    => locAxilWriteSlaves(AXIL_TES_DELATCH_C),   -- [out]
+         writeRegister(0) => tesDelatchInt);                           -- [out]
+
+   tesDelatch <= tesDelatchInt(7 downto 0);
 
    -------------------------------------------------------------------------------------------------
    -- ADC Config

--- a/firmware/targets/ColumnModule/sim/ColumnModuleBoard.vhd
+++ b/firmware/targets/ColumnModule/sim/ColumnModuleBoard.vhd
@@ -33,6 +33,7 @@ entity ColumnModuleBoard is
    generic (
       TPD_G                   : time    := 1 ns;
       RING_ADDR_0_G           : boolean := false;
+      SIMULATE_PGP_G          : boolean := false;
       SIM_PGP_PORT_NUM_G      : integer := 7000;
       SIM_ETH_SRP_PORT_NUM_G  : integer := 8000;
       SIM_ETH_DATA_PORT_NUM_G : integer := 9000);
@@ -193,6 +194,7 @@ begin
       generic map (
          TPD_G                   => TPD_G,
          SIMULATION_G            => SIMULATION_G,
+         SIMULATE_PGP_G          => SIMULATE_PGP_G,
          SIM_PGP_PORT_NUM_G      => SIM_PGP_PORT_NUM_G,
          SIM_ETH_SRP_PORT_NUM_G  => SIM_ETH_SRP_PORT_NUM_G,
          SIM_ETH_DATA_PORT_NUM_G => SIM_ETH_DATA_PORT_NUM_G,
@@ -543,7 +545,7 @@ begin
       amplitude(i)    <= ite(amplitudeTmp(i) < 0.0, 0.0, amplitudeTmp(i));
 
       fbCurrent(i)    <= saFbOut(i)/R_FB_SHUNT_C;
-      saResistance(i) <= 100.0; --125.0 + amplitude(i) * cos(fbCurrent(i) * 2 * MATH_PI / PHI_NOT_C - saBias(i)) + amplitude(i);
+      saResistance(i) <= 100.0;  --125.0 + amplitude(i) * cos(fbCurrent(i) * 2 * MATH_PI / PHI_NOT_C - saBias(i)) + amplitude(i);
 
       saSig(i) <= saBias(i) * saResistance(i) / (saResistance(i) + R_BIAS_C);
 

--- a/firmware/targets/ColumnModule/sim/ColumnModuleBoardTb.vhd
+++ b/firmware/targets/ColumnModule/sim/ColumnModuleBoardTb.vhd
@@ -41,6 +41,9 @@ architecture sim of ColumnModuleBoardTb is
    signal rj45TimingClkN  : slv(NUM_COLUMN_MODULES_C-1 downto 0);  -- [in]
    signal rj45TimingDataP : slv(NUM_COLUMN_MODULES_C-1 downto 0);  -- [in]
    signal rj45TimingDataN : slv(NUM_COLUMN_MODULES_C-1 downto 0);  -- [in]
+   signal rj45TimingMgtP  : slv(NUM_COLUMN_MODULES_C-1 downto 0);  -- [in]
+   signal rj45TimingMgtN  : slv(NUM_COLUMN_MODULES_C-1 downto 0);  -- [in]
+
 
 begin
 
@@ -48,20 +51,28 @@ begin
    ColumnModGen : for i in 0 to NUM_COLUMN_MODULES_C-1 generate
       U_ColumnModuleBoard : entity warm_tdm.ColumnModuleBoard
          generic map (
-            TPD_G                  => TPD_G,
-            RING_ADDR_0_G          => (i = 0),
-            SIM_PGP_PORT_NUM_G     => 7000, --7000 + (10*i),
-            SIM_ETH_SRP_PORT_NUM_G => 10000 + (1000*i),
+            TPD_G                   => TPD_G,
+            RING_ADDR_0_G           => (i = 0),
+            SIMULATE_PGP_G          => false,
+            SIM_PGP_PORT_NUM_G      => 7000,  --7000 + (10*i),
+            SIM_ETH_SRP_PORT_NUM_G  => 10000 + (1000*i),
             SIM_ETH_DATA_PORT_NUM_G => 20000 + (1000*i))
          port map (
             rj45TimingRxClkP  => rj45TimingClkP(ite(i = 0, NUM_COLUMN_MODULES_C-1, i-1)),   -- [in]
             rj45TimingRxClkN  => rj45TimingClkN(ite(i = 0, NUM_COLUMN_MODULES_C-1, i-1)),   -- [in]
             rj45TimingRxDataP => rj45TimingDataP(ite(i = 0, NUM_COLUMN_MODULES_C-1, i-1)),  -- [in]
             rj45TimingRxDataN => rj45TimingDataN(ite(i = 0, NUM_COLUMN_MODULES_C-1, i-1)),  -- [in]
+            rj45TimingRxMgtP  => rj45TimingMgtP(ite(i = 0, NUM_COLUMN_MODULES_C-1, i-1)),   -- [in]
+            rj45TimingRxMgtN  => rj45TimingMgtN(ite(i = 0, NUM_COLUMN_MODULES_C-1, i-1)),   -- [in]
+            rj45PgpRxMgtP     => '1',   -- [in]
+            rj45PgpRxMgtN     => '0',   -- [in]
             rj45TimingTxClkP  => rj45TimingClkP(i),                                         -- [out]
             rj45TimingTxClkN  => rj45TimingClkN(i),                                         -- [out]
             rj45TimingTxDataP => rj45TimingDataP(i),                                        -- [out]
-            rj45TimingTxDataN => rj45TimingDataN(i));                                       -- [out]
+            rj45TimingTxDataN => rj45TimingDataN(i),                                        -- [out]
+            rj45TimingTxMgtP  => rj45TimingMgtP(i),
+            rj45TimingTxMgtN  => rj45TimingMgtN(i));
+
    end generate ColumnModGen;
 
 

--- a/firmware/targets/RowModule/rtl/RowModule.vhd
+++ b/firmware/targets/RowModule/rtl/RowModule.vhd
@@ -40,6 +40,7 @@ entity RowModule is
    generic (
       TPD_G                   : time                  := 1 ns;
       SIMULATION_G            : boolean               := false;
+      SIMULATE_PGP_G          : boolean               := true;
       SIM_PGP_PORT_NUM_G      : integer               := 0;
       SIM_ETH_SRP_PORT_NUM_G  : integer               := 8000;
       SIM_ETH_DATA_PORT_NUM_G : integer               := 9000;
@@ -200,6 +201,7 @@ begin
       generic map (
          TPD_G                   => TPD_G,
          SIMULATION_G            => SIMULATION_G,
+         SIMULATE_PGP_G          => SIMULATE_PGP_G,
          SIM_PGP_PORT_NUM_G      => SIM_PGP_PORT_NUM_G,
          SIM_ETH_SRP_PORT_NUM_G  => SIM_ETH_SRP_PORT_NUM_G,
          SIM_ETH_DATA_PORT_NUM_G => SIM_ETH_DATA_PORT_NUM_G,

--- a/firmware/targets/RowModule/sim/RowModuleBoard.vhd
+++ b/firmware/targets/RowModule/sim/RowModuleBoard.vhd
@@ -32,6 +32,7 @@ entity RowModuleBoard is
    generic (
       TPD_G                   : time    := 1 ns;
       RING_ADDR_0_G           : boolean := false;
+      SIMULATE_PGP_G          : boolean := false;
       SIM_PGP_PORT_NUM_G      : integer := 7000;
       SIM_ETH_SRP_PORT_NUM_G  : integer := 8000;
       SIM_ETH_DATA_PORT_NUM_G : integer := 9000;
@@ -137,6 +138,7 @@ begin
       generic map (
          TPD_G                   => TPD_G,
          SIMULATION_G            => SIMULATION_G,
+         SIMULATE_PGP_G          => SIMULATE_PGP_G,
          SIM_PGP_PORT_NUM_G      => SIM_PGP_PORT_NUM_G,
          SIM_ETH_SRP_PORT_NUM_G  => SIM_ETH_SRP_PORT_NUM_G,
          SIM_ETH_DATA_PORT_NUM_G => SIM_ETH_DATA_PORT_NUM_G,

--- a/software/python/warm_tdm_api/_CurveClass.py
+++ b/software/python/warm_tdm_api/_CurveClass.py
@@ -12,6 +12,11 @@ def plotCurveDataDict(ax, curveDataDict, ax_title, xlabel, ylabel, legend_title)
         ax.set_xlabel(xlabel)
         ax.grid(True)
 
+        # Special case for no data
+        if curveDataDict is None:
+            ax.text(.5, .5, 'Not Tuned', ha='center', va='center', fontsize=28)
+            return
+
         # Special case for CurveData with no curves
         if len(curveDataDict['biasValues']) == 0:
             ax.text(.5, .5, 'Not Tuned', ha='center', va='center', fontsize=28)

--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -27,6 +27,7 @@ class GroupLinkVariable(pr.LinkVariable):
             linkedGet=self._get,
             groups=groups,
             disp=disp,
+            groups = ['NoConfig'],
             **kwargs)
         self.tuneEnVar = tuneEnVar
         deps =  kwargs['dependencies']
@@ -229,6 +230,7 @@ class Group(pr.Device):
                 units = arrVar.units,
                 guiGroup = arrVar.name,
                 dependencies = [arrVar],
+                groups = ['NoConfig'],
                 linkedGet = lambda read, x=i: arrVar.get(read=read, index=x),
                 linkedSet = None if arrVar.mode == 'RO' else lambda value, write, x=i: arrVar.set(value, write=write, index=x)))
             
@@ -358,6 +360,7 @@ class Group(pr.Device):
 
         self.add(pr.LinkVariable(
             name = 'RowIndexOrderList',
+            groups = ['NoConfig']
             variable = self.HardwareGroup.ReadoutList))
 
         # Tuning column enables
@@ -567,7 +570,6 @@ class Group(pr.Device):
                             for m in self.config.columnMap],
             config = self.config,
             disp = '{:0.03f}',))
-#            units = 'mV'))
 
 
         self.add(SaOutVariable(
@@ -577,7 +579,6 @@ class Group(pr.Device):
             'Values can be accessed as a full array or as single values using an index key.',
             dependencies = [self.HardwareGroup.ColumnBoard[m.board].SaOutNorm
                             for m in self.config.columnMap],
-#            units = 'mV',            
             config = self.config,
             disp = '{:0.03f}'))
 
@@ -590,7 +591,6 @@ class Group(pr.Device):
                          'Values can be accessed as a full 2D array or pass a (col, row) tuple for the index key to access each value.',
             config = self.config,
             hidden = False,
-#            units = 'mA',
             dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.Column[m.channel].Current
                             for m in self.config.columnMap]))
 
@@ -601,7 +601,6 @@ class Group(pr.Device):
                          'Values can be accessed as a full array or as single values using an index key.',
             dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.OverrideCurrent[m.channel]
                             for m in self.config.columnMap],
-#            units = 'mA',
             tuneEnVar = self.ColTuneEnable))
 
 
@@ -612,7 +611,6 @@ class Group(pr.Device):
                          'Values can be accessed as a full 2D array or pass a (col, row) tuple for the index key to access each value.',
             config = self.config,
             hidden = True,
-#            units = 'V',
             dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.Column[m.channel].Voltage
                             for m in self.config.columnMap]))
 
@@ -623,7 +621,6 @@ class Group(pr.Device):
                          'Values can be accessed as a full array or as single values using an index key.',
             dependencies = [self.HardwareGroup.ColumnBoard[m.board].SAFb.OverrideVoltage[m.channel]
                             for m in self.config.columnMap],
-#            units = 'V',
             tuneEnVar = self.ColTuneEnable))
 
 
@@ -782,7 +779,7 @@ class Group(pr.Device):
 #            linkedGet=self._fllEnableGet,
             description="FLL Enable Control."))
 
-        self.add(warm_tdm_api.ConfigSelect(self,groups=['NoDoc']))
+        self.add(warm_tdm_api.ConfigSelect(self,groups=['NoDoc', 'NoConfig']))
 
         #############################################
         # Tuning and diagnostic Processes

--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -171,6 +171,7 @@ class FastDacVariable(GroupLinkVariable):
     def __init__(self, config, **kwargs):
 
         self._config = config
+
         if 'hidden' not in kwargs:
             kwargs['hidden'] = True
 
@@ -206,7 +207,7 @@ class FastDacVariable(GroupLinkVariable):
 
             # Full array access
             else:
-                rows = 32 #256 #len(self._config.rowMap)
+                rows = 32
                 cols = len(self._config.columnMap)
 
                 ret = np.zeros((cols, rows), np.float64)
@@ -231,7 +232,7 @@ class Group(pr.Device):
                 linkedGet = lambda read, x=i: arrVar.get(read=read, index=x),
                 linkedSet = None if arrVar.mode == 'RO' else lambda value, write, x=i: arrVar.set(value, write=write, index=x)))
             
-    def __init__(self, groupConfig, groupId, frontEndClass, dataWriter, simulation=False, emulate=False, plots=False, **kwargs):
+    def __init__(self, groupConfig, groupId, rows, frontEndClass, dataWriter, simulation=False, emulate=False, plots=False, **kwargs):
         """
         Warm TDM Device
         Parameters
@@ -262,7 +263,7 @@ class Group(pr.Device):
             host=groupConfig.host,
             colBoards=groupConfig.columnBoards,
             rowBoards=groupConfig.rowBoards,
-            rows=32,
+            rows=rows,
             plots=plots,
             groups=['Hardware'],
             expand=True))

--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -231,7 +231,7 @@ class Group(pr.Device):
                 linkedGet = lambda read, x=i: arrVar.get(read=read, index=x),
                 linkedSet = None if arrVar.mode == 'RO' else lambda value, write, x=i: arrVar.set(value, write=write, index=x)))
             
-    def __init__(self, groupConfig, groupId, dataWriter, simulation=False, emulate=False, plots=False, **kwargs):
+    def __init__(self, groupConfig, groupId, frontEndClass, dataWriter, simulation=False, emulate=False, plots=False, **kwargs):
         """
         Warm TDM Device
         Parameters
@@ -255,6 +255,7 @@ class Group(pr.Device):
         # Add the Hardware Device tree
         self.add(warm_tdm.HardwareGroup(
             groupId=groupId,
+            frontEndClass=frontEndClass,
             dataWriter=dataWriter,
             simulation=simulation,
             emulate=emulate,

--- a/software/python/warm_tdm_api/_GroupRoot.py
+++ b/software/python/warm_tdm_api/_GroupRoot.py
@@ -4,7 +4,7 @@ import warm_tdm_api
 
 
 class GroupRoot(pyrogue.Root):
-    def __init__(self, groupConfig, simulation=False, emulate=False, plots=False, **kwargs):
+    def __init__(self, groupConfig, frontEndClass, simulation=False, emulate=False, plots=False, **kwargs):
         """
         Root class container for Warm-TDM Groups.
         Parameters
@@ -48,6 +48,7 @@ class GroupRoot(pyrogue.Root):
         self.add(warm_tdm_api.Group(
             groupConfig=groupConfig,
             groupId=0,
+            frontEndClass=frontEndClass,
             expand=True,
             dataWriter=self.DataWriter,
             simulation=simulation,

--- a/software/python/warm_tdm_api/_GroupRoot.py
+++ b/software/python/warm_tdm_api/_GroupRoot.py
@@ -37,7 +37,7 @@ class GroupRoot(pyrogue.Root):
         self.Initialize.addToGroup('DocApi')
 
         # Add the data writer
-        self.add(pyrogue.utilities.fileio.StreamWriter(name='DataWriter',groups='DocApi'))
+        self.add(pyrogue.utilities.fileio.StreamWriter(name='DataWriter',groups=['DocApi', 'NoConfig']))
         #self >> self.DataWriter.getChannel(100)
         self.DataWriter.ReadDevice.addToGroup('NoDoc')
         self.DataWriter.WriteDevice.addToGroup('NoDoc')

--- a/software/python/warm_tdm_api/_GroupRoot.py
+++ b/software/python/warm_tdm_api/_GroupRoot.py
@@ -4,7 +4,7 @@ import warm_tdm_api
 
 
 class GroupRoot(pyrogue.Root):
-    def __init__(self, groupConfig, frontEndClass, simulation=False, emulate=False, plots=False, **kwargs):
+    def __init__(self, groupConfig, frontEndClass, numRows, simulation=False, emulate=False, plots=False, **kwargs):
         """
         Root class container for Warm-TDM Groups.
         Parameters
@@ -48,6 +48,7 @@ class GroupRoot(pyrogue.Root):
         self.add(warm_tdm_api.Group(
             groupConfig=groupConfig,
             groupId=0,
+            rows=numRows,
             frontEndClass=frontEndClass,
             expand=True,
             dataWriter=self.DataWriter,

--- a/software/scripts/PromLoader
+++ b/software/scripts/PromLoader
@@ -65,8 +65,20 @@ parser.add_argument(
     default = 1,
     help     = "Number of column modules")
 
+parser.add_argument(
+    "--frontEnd",
+    choices= ['Standard', 'Ch0Feb'],
+    default= 'Standard')
+
 args = parser.parse_known_args()[0]
 print(args)
+
+feDict = {
+    'Standard': warm_tdm.ColumnBoardC00StandardFrontEnd,
+    'Ch0Feb': warm_tdm.ColumnBoardC00FebBypassCh0}
+
+feClass = feDict[args.frontEnd]
+
 
 groups = [{
     'host': args.ip,
@@ -92,6 +104,7 @@ kwargs = {}
 with warm_tdm.WarmTdmRoot(
         pollEn=False,
         host=args.ip,
+        frontEndClass = feClass,
         colBoards=args.cols,
         rowBoards=args.rows,
         **kwargs) as root:

--- a/software/scripts/warmTdmGui.py
+++ b/software/scripts/warmTdmGui.py
@@ -104,7 +104,7 @@ config = warm_tdm_api.GroupConfig(rowBoards=groups[0]['rowBoards'],
 # root.start()
 # #pyrogue.waitCntrlC()
 
-with warm_tdm_api.GroupRoot(groupConfig=config, frontEndClass=feClass, simulation=args.sim, emulate=args.emulate, plots=args.plots, initRead=not args.sim) as root:
+with warm_tdm_api.GroupRoot(groupConfig=config, frontEndClass=feClass, numRows=32, simulation=args.sim, emulate=args.emulate, plots=args.plots, initRead=not args.sim) as root:
 
     if args.docs != '':
         root.genDocuments(path=args.docs,incGroups=['DocApi'],excGroups=['NoDoc','Enable','Hardware'])

--- a/software/scripts/warmTdmGui.py
+++ b/software/scripts/warmTdmGui.py
@@ -126,7 +126,7 @@ with warm_tdm_api.GroupRoot(groupConfig=config, frontEndClass=feClass, numRows=3
         serverList=root.zmqServer.address,
         title='Warm TDM',
         sizeX=2000,
-        sizeY=2000,
+        sizeY=1600,
         ui=warm_tdm_api.pydmUi)
 
 

--- a/software/scripts/warmTdmGui.py
+++ b/software/scripts/warmTdmGui.py
@@ -11,6 +11,7 @@ pyrogue.addLibraryPath(f'../../firmware/python/')
 pyrogue.addLibraryPath(f'../../firmware/submodules/surf/python')
 
 import warm_tdm_api
+import warm_tdm
 
 from warm_tdm_api import PhysicalMap as pm
 
@@ -72,9 +73,21 @@ parser.add_argument(
     default = '',
     help     = "Path To Store Docs")
 
+parser.add_argument(
+    "--frontEnd",
+    choices= ['Standard', 'Ch0Feb'],
+    default= 'Standard')
+
+
 
 args = parser.parse_known_args()[0]
 print(args)
+
+feDict = {
+    'Standard': warm_tdm.ColumnBoardC00StandardFrontEnd,
+    'Ch0Feb': warm_tdm.ColumnBoardC00FebBypassCh0}
+
+feClass = feDict[args.frontEnd]
 
 groups = [{
     'host': args.ip,
@@ -91,7 +104,7 @@ config = warm_tdm_api.GroupConfig(rowBoards=groups[0]['rowBoards'],
 # root.start()
 # #pyrogue.waitCntrlC()
 
-with warm_tdm_api.GroupRoot(groupConfig=config, simulation=args.sim, emulate=args.emulate, plots=args.plots, initRead=not args.sim) as root:
+with warm_tdm_api.GroupRoot(groupConfig=config, frontEndClass=feClass, simulation=args.sim, emulate=args.emulate, plots=args.plots, initRead=not args.sim) as root:
 
     if args.docs != '':
         root.genDocuments(path=args.docs,incGroups=['DocApi'],excGroups=['NoDoc','Enable','Hardware'])


### PR DESCRIPTION
- Improve front end amplifier software models and their modularity.
- Add TES Bias amplifier modeling.
- Adjust DSP PID coefficient to 24 bits, accumulator to 18 bits.
- Fix PID debug sign extend (maybe still  broken).
- Remove readout stream FIFO that didn't go anywhere (for now).
- Add ADC FIR filter back (for now).
- Add synchronized waveform capture feature.
- Fix SQ1FB Tune software bug where it hangs when an untuned row is selected.