### PR TITLE
Add missing packages to requirements, add some basic setup instructions, bump gh-actions python version

### DIFF
--- a/.github/workflows/warm_tdm_ci.yml
+++ b/.github/workflows/warm_tdm_ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@
 
    https://slaclab.github.io/warm-tdm/
 
+# Quick Start
+First, initialize the submodules for this repo:
+```
+git submodule update --init --recursive
+```
+
+Then create a conda environment with the latest version of rogue, activate it, and then install the required pip packages into it:
+```
+conda create -n warm-tdm-env -c tidair-tag -c conda-forge rogue
+conda activate warm-tdm-env
+pip install -r pip_requirements.txt
+```
+
+Lastly, to test that everything is installed correctly you can launch the main gui (without needing any hardware connected) as follows:
+```
+python software/scripts/warmTdmGui.py --emulate
+```

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -3,3 +3,5 @@ sphinx_rtd_theme
 sphinxcontrib-napoleon
 flake8
 simple_pid
+sympy
+scipy


### PR DESCRIPTION
- add pip packages missing from requirements 

- add some instructions i find useful

- bump python version used in gh-actions since 3.8 is old. also if you try installing rogue with 3.8 in conda it defaults to an old version that doesn't work with gui script.