### PR TITLE
Add some basic setup instructions, bump gh-actions python version

### DIFF
--- a/.github/workflows/warm_tdm_ci.yml
+++ b/.github/workflows/warm_tdm_ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@
 
    https://slaclab.github.io/warm-tdm/
 
+# Quick Start
+First, initialize the submodules for this repo:
+```
+git submodule update --init --recursive
+```
+
+Then use mamba to create a conda environment using the project's conda.yml file, and then activate it:
+```
+mamba env create --file conda.yml --name warm-tdm-env
+mamba activate warm-tdm-env
+```
+
+Lastly, to test that everything is installed correctly you can launch the main gui (without needing any hardware connected) as follows:
+```
+python software/scripts/warmTdmGui.py --emulate
+```

--- a/conda.yml
+++ b/conda.yml
@@ -31,3 +31,4 @@ dependencies:
   - jupyterlab
   - simple-pid
   - sympy
+  - scipy


### PR DESCRIPTION
(re-uploading these changes as a PR from branch instead of fork)

- add some instructions i find useful,

- bump python version used in gh-actions since 3.8 is old. also if you try installing rogue with 3.8 in conda it defaults to an old version that doesn't work with gui script.