### PR TITLE
Fix duplicate tune-plot legend entries (#35)

### DIFF
--- a/software/python/warm_tdm_api/_CurveClass.py
+++ b/software/python/warm_tdm_api/_CurveClass.py
@@ -33,7 +33,10 @@ def plotCurveDataDict(ax, curveDataDict, ax_title, xlabel, ylabel, legend_title)
                 linewidth = 2.0
             peak = curveDataDict['peaks'][biasIndex]
             phinot = curveDataDict['phinots'][biasIndex]
-            label = f'{value:1.3f} - P-P: {peak:1.3f} - $\\phi_o$: {phinot:.2f}'
+            # Prefix with the curve index so every entry is unique: bias values
+            # closer together than the displayed precision would otherwise
+            # collide into identical legend labels (issue #35).
+            label = f'[{biasIndex}] {value:1.3f} - P-P: {peak:1.3f} - $\\phi_o$: {phinot:.2f}'
             color = ax._get_lines.get_next_color()
             # Plot the curve
             ax.plot(xValues, curveDataDict['curves'][biasIndex], label=label, linewidth=linewidth, color=color)


### PR DESCRIPTION
## Summary

Fixes duplicate entries in the SQ1 (and SA) tune-plot legends (#35).

## Root cause

Not a plot-accumulation bug — `plotCurveDataDict` already calls `ax.clear()` and
reuses the figure, so re-rendering does not stack entries (verified: a double
render stays at N entries, not 2N).

The real cause is **label collision**. Each legend label was built only from the
bias value / peak / phinot at 3-decimal precision:

```
f'{value:1.3f} - P-P: {peak:1.3f} - $\phi_o$: {phinot:.2f}'
```

When the bias sweep step is finer than that precision — or biases repeat (e.g.
`doBiasRamp=False` retuning at a single loaded bias) — multiple curves produce
**identical label strings**, which render as duplicate legend rows.

## Fix

Prefix each label with its curve index so every entry is unique (N curves → N
distinct legend entries), keeping the informative bias / P-P / φ₀ text:

```
f'[{biasIndex}] {value:1.3f} - P-P: {peak:1.3f} - $\phi_o$: {phinot:.2f}'
```

`plotCurveDataDict` is shared by the SA and SQ1 tune plots, so this covers both.

## Validation

Emulation (matplotlib Agg), no hardware:

- Reproduced the bug: 12 curves at an identical bias → 12 identical legend labels.
- After the fix: the same case yields **12 distinct** legend entries (`[0] …`,
  `[1] …`, …) plus the single `Tune Point`; all curve labels unique.

Not yet eyeballed against a live tune plot on hardware — the change is label-string
only, so low risk, but a visual confirmation before/after is worth doing on the bench.



Closes #35
