### PR TITLE
Add software TES bias waveform generator

### DIFF
--- a/software/python/warm_tdm_api/_Group.py
+++ b/software/python/warm_tdm_api/_Group.py
@@ -426,4 +426,5 @@ class Group(pr.Device):
             self.add(warm_tdm_api.FasTuneProcess(groups=['NoDoc']))
             self.add(warm_tdm_api.Sq1DiagProcess(groups=['NoDoc']))
             self.add(warm_tdm_api.TesRampProcess(groups=['NoDoc']))
+            self.add(warm_tdm_api.TesBiasWaveformProcess(groups=['NoDoc']))
             self.add(warm_tdm_api.SaStripChartProcess(groups=['NoDoc']))

--- a/software/python/warm_tdm_api/_TesBiasWaveform.py
+++ b/software/python/warm_tdm_api/_TesBiasWaveform.py
@@ -1,0 +1,260 @@
+"""
+TES Bias Waveform Generator
+
+This module provides a TES bias waveform generator to create various waveforms for testing and characterization purposes.
+
+The `TesBiasWaveformProcess` class is the main entry point for generating waveforms. It manages the waveform generation process and updates the TES bias values accordingly.
+
+The available waveform types are:
+- Sine wave
+- Square wave
+- Nothing (no waveform)
+"""
+
+import pyrogue as pr
+import warm_tdm_api
+import numpy as np
+import time
+from functools import partial
+
+def wfsin(t, f, low, high):
+    """
+    Generate a sine wave waveform.
+
+    Args:
+        t (float): Time value.
+        f (float): Frequency of the sine wave.
+        low (float): Lower limit of the waveform.
+        high (float): Upper limit of the waveform.
+
+    Returns:
+        float: The value of the sine wave waveform at time `t`.
+    """
+    return ((high - low) / 2.) * np.sin(2. * np.pi * f * t) + (high + low) / 2.
+
+def wfstep(t, f, low, high):
+    """
+    Generate a square wave waveform.
+
+    Args:
+        t (float): Time value.
+        f (float): Frequency of the square wave.
+        low (float): Lower limit of the waveform.
+        high (float): Upper limit of the waveform.
+
+    Returns:
+        float: The value of the square wave waveform at time `t`.
+    """
+    return (high - low) * (np.floor(t * 2 * f) % 2 >= 1).astype(float) + low
+
+def wfconst(t, const):
+    """
+    Generate a constant waveform.
+
+    Args:
+        t (float): Time value (not used).
+        const (float): The constant value to return.
+
+    Returns:
+        float: The constant value.
+    """
+    return const
+
+class TesBiasWaveformProcess(pr.Process):
+    """
+    TES Bias Waveform Generator Process
+
+    This class manages the generation of various waveforms for the TES bias lines.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the TES Bias Waveform Generator Process.
+
+        Args:
+            **kwargs: Additional keyword arguments passed to the parent class.
+        """
+        pr.Process.__init__(self, function=self._tesBiasWaveformWrap, **kwargs)
+
+        self.add(pr.LocalVariable(name='SoftwareClock',
+                                  value=1000.,
+                                  units='Hz',
+                                  mode='RW',
+                                  description='Software update rate.'))
+
+        self._waveformGeneratorCount = 0
+        self._ensureWaveformGenerators(getattr(self, 'parent', None))
+
+    def _getWaveformGeneratorCount(self, group):
+        """
+        Determine the number of TES bias waveform generators required for the
+        attached group configuration.
+        """
+        if group is not None:
+            tes_bias = getattr(group, 'TesBias', None)
+            if tes_bias is not None:
+                try:
+                    return len(tes_bias.get())
+                except TypeError:
+                    pass
+
+            column_map = getattr(group, 'ColumnMap', None)
+            if column_map is not None:
+                try:
+                    return len(column_map.get())
+                except TypeError:
+                    pass
+
+        return 8
+
+    def _ensureWaveformGenerators(self, group):
+        """
+        Ensure that there is one waveform generator per TES bias entry.
+        """
+        required_count = self._getWaveformGeneratorCount(group)
+
+        for i in range(self._waveformGeneratorCount, required_count):
+            self.add(warm_tdm_api.tesBiasWaveformGenerator(
+                name=f'tesBiasWaveformGenerator[{i}]'))
+
+        self._waveformGeneratorCount = required_count
+
+    def _tesBiasWaveformWrap(self):
+        """
+        Wrap the TES bias waveform generation process.
+        """
+        self._ensureWaveformGenerators(self.parent)
+        tesBiasWaveform(group=self.parent, process=self)
+
+def tesBiasWaveform(*, group, process=None):
+    """
+    Generate TES bias waveforms and update the TES bias values.
+
+    Args:
+        group (pr.Device): The parent device group.
+        process (TesBiasWaveformProcess, optional): The TES bias waveform process instance.
+    """
+    process._log.info("TesBiasWaveformProcess Running.")
+
+    # Remember initial biases
+    orig_tes_bias = group.TesBias.get()
+
+    # Prepare waveforms
+    wfs = []
+
+    # Number of generators is sized dynamically by _ensureWaveformGenerators
+    # (one per TES bias entry); use that count rather than a hardcode.
+    num_generators = process._waveformGeneratorCount
+    if len(orig_tes_bias) != num_generators:
+        raise ValueError(
+            f"TES bias vector length ({len(orig_tes_bias)}) does not match "
+            f"the number of waveform generators ({num_generators}).")
+
+    enum0 = process.tesBiasWaveformGenerator[0].Mode.enum
+    valid_modes = {'None', 'Sine', 'Square'}
+    modes = []
+    for ii in range(num_generators):
+        mode_value = process.tesBiasWaveformGenerator[ii].Mode.get()
+        mode = enum0.get(mode_value)
+        if mode is None or mode not in valid_modes:
+            raise ValueError(
+                f"Unsupported TES bias waveform mode for generator {ii}: "
+                f"raw value={mode_value!r}, resolved mode={mode!r}. "
+                f"Expected one of {sorted(valid_modes)}.")
+
+        modes.append(mode)
+        if mode == 'None':
+            const = orig_tes_bias[ii]
+            wfs.append(partial(wfconst, const=const))
+        elif mode == 'Sine':
+            f_hz = process.tesBiasWaveformGenerator[ii].Frequency.get()
+            low_ua = process.tesBiasWaveformGenerator[ii].TESBiasLow.get()
+            high_ua = process.tesBiasWaveformGenerator[ii].TESBiasHigh.get()
+            wfs.append(partial(wfsin, f=f_hz, low=low_ua, high=high_ua))
+        elif mode == 'Square':
+            f_hz = process.tesBiasWaveformGenerator[ii].Frequency.get()
+            low_ua = process.tesBiasWaveformGenerator[ii].TESBiasLow.get()
+            high_ua = process.tesBiasWaveformGenerator[ii].TESBiasHigh.get()
+            wfs.append(partial(wfstep, f=f_hz, low=low_ua, high=high_ua))
+        else:
+            raise ValueError(
+                f"Unhandled TES bias waveform mode for generator {ii}: {mode!r}")
+
+    if len(wfs) != len(orig_tes_bias):
+        raise ValueError(
+            f"Generated {len(wfs)} waveform functions for "
+            f"{len(orig_tes_bias)} TES bias entries.")
+    # If none of the generators are configured, print error and stop
+    if all(mode == 'None' for mode in modes):
+        process._log.warning("All generators configured for 'None', nothing to do. Stopping TesBiasWaveformProcess.")
+        return
+
+    # Play waveforms
+    new_tes_bias = orig_tes_bias.copy()
+    last_tes_bias = orig_tes_bias.copy()
+    clk_hz = process.SoftwareClock.get()
+    dt = 1. / clk_hz
+    t0 = time.time()
+    counter = 0
+    while True:
+        step_t = counter * dt
+        t = time.time()
+        # No rest for the wicked
+        while t - t0 < step_t:
+            time.sleep(0.000010) # 10 us delay to reduce cpu usage 
+            t = time.time()
+
+        new_tes_bias = np.array([wf(t - t0) for wf in wfs])
+        if not np.allclose(new_tes_bias, last_tes_bias):
+            group.TesBias.set(new_tes_bias)
+            last_tes_bias = new_tes_bias.copy()
+
+        # Check for stopped process
+        if process is not None and process._runEn == False:
+            process._log.info('TesBiasWaveformProcess stopped, returning TES biases to original values')
+            group.TesBias.set(orig_tes_bias)
+            break
+
+        counter += 1
+
+class tesBiasWaveformGenerator(pr.Device):
+    """
+    TES Bias Waveform Generator
+
+    This class provides a way to configure the waveform generation for a single TES bias line.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the TES Bias Waveform Generator.
+
+        Args:
+            **kwargs: Additional keyword arguments passed to the parent class.
+        """
+        super().__init__(**kwargs)
+        self.add(pr.LocalVariable(
+            name='Mode',
+            value=0,
+            mode='RW',
+            enum={
+                0: 'None',
+                1: 'Square',
+                2: 'Sine'}))
+
+        self.add(pr.LocalVariable(name='Frequency',
+                                  value=1.0,
+                                  units='Hz',
+                                  mode='RW',
+                                  description='Frequency of waveform generated on TES bias line.'))
+
+        self.add(pr.LocalVariable(name='TESBiasLow',
+                                  value=0,
+                                  units='uA',
+                                  mode='RW',
+                                  description='Low-level value of waveform generated on TES bias line.'))
+
+        self.add(pr.LocalVariable(name='TESBiasHigh',
+                                  value=1,
+                                  units='uA',
+                                  mode='RW',
+                                  description='High-level value of waveform generated on TES bias line.'))

--- a/software/python/warm_tdm_api/__init__.py
+++ b/software/python/warm_tdm_api/__init__.py
@@ -8,6 +8,7 @@ from ._SaTune import *
 from ._Sq1Diag import *
 from ._Sq1Tune import *
 from ._TesRamp import *
+from ._TesBiasWaveform import *
 from ._Tuning import *
 from ._ConfigSelect import *
 from ._SaStripChart import *


### PR DESCRIPTION
Closes #55.

Adds the software TES bias waveform generator — `TesBiasWaveformProcess` (a
`pr.Process`) plus the `tesBiasWaveformGenerator` device — which plays
software-clocked sine / square / constant waveforms on the TES bias lines for
testing and characterization. Registered on `Group` alongside the other
tuning/diagnostic processes and exported from `warm_tdm_api`.

- Generator count is sized dynamically to the group's `TesBias` length (one per
  entry), not hardcoded.
- Status/stop/idle messages go through the process logger, not `print`.

**Split out of #68/PR #78** so it can land independently: it's a server-side
device node with no dependency on the `warm_tdm_api.operations` client layer
being reworked in #78. Once merged, #78 picks it up via the next
`pre-release`→`wtj-refactor` merge and shrinks to just the operations work.

Validated in emulate mode: process registers on `Group`, 8 generators created,
full GroupRoot start/stop lifecycle clean.