### PR TITLE
Fix broken warm_tdm_api import from PR #84 emulate removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,8 +206,8 @@ python warmTdmGui.py
 # Command-line client
 python warmTdmClientCmd.py
 
-# Emulation mode (no hardware)
-python warmTdmEmulate.py
+# Emulation mode (no hardware — fakes register memory via MemEmulate)
+python Jupyter.py --emulate
 ```
 
 ## Releases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ python warmTdmGui.py
 python warmTdmClientCmd.py
 
 # Emulation mode (no hardware — fakes register memory via MemEmulate)
-python Jupyter.py --emulate
+python warmTdmGui.py --emulate       # or warmTdmServer.py --emulate (headless)
 ```
 
 ## Releases

--- a/software/python/warm_tdm_api/__init__.py
+++ b/software/python/warm_tdm_api/__init__.py
@@ -12,9 +12,6 @@ from ._Tuning import *
 from ._ConfigSelect import *
 from ._SaStripChart import *
 from ._ArgParser import *
-#from ._TdmDataReceiver import *
-#from ._TdmGroupEmulate import *
-from ._RunEmulate import *
 from warm_tdm_api.widgets import WarmTdmDisplay
 from ._server import runServer
 


### PR DESCRIPTION
## Summary

PR #84 (#72 — retire the dead `warmTdmEmulate` prototype) deleted `_RunEmulate.py`, but the follow-up commit that removed its import from `warm_tdm_api/__init__.py` did not make it into the merge. As a result **`import warm_tdm_api` raises `ImportError` on `pre-release`** (`from ._RunEmulate import *` → no such module).

## Changes

- Remove the stale `from ._RunEmulate import *` and the two dead commented `TdmDataReceiver`/`TdmGroupEmulate` import lines from `__init__.py`.
- Point AGENTS.md "Emulation mode" at `warmTdmGui.py --emulate` (or `warmTdmServer.py --emulate` for headless) instead of the removed `warmTdmEmulate.py`. Both route through `runServer` → `WarmTdmArgparse`; the flag is `--emulate` and it selects the live `MemEmulate` register path.

## Verification

`import warm_tdm_api` succeeds against a clean checkout of this branch's HEAD (verified via `git archive`, not the working tree) in `warm-tdm-env`.

Follow-up to #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)